### PR TITLE
Fix verbose mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 clap = "3.0.0-beta.2"
 log = "0.4"
+env_logger = "0.9.0"
 base64 = "0.13.0"
 rayon = "1.5.1"
 petgraph = "0.6.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use ares::perform_cracking;
 mod cli_input_parser;
 
-use clap::{Parser};
+use clap::Parser;
+use env_logger;
+
 use log::trace;
 
 /// This doc string acts as a help message when the user runs '--help'
@@ -19,8 +21,17 @@ struct Opts {
 }
 
 fn main() {
-    trace!("Program was called with CLI 😉");
     let opts: Opts = Opts::parse();
+    let min_log_level = match opts.verbose {
+        0 => "Warn",
+        1 => "Info",
+        2 => "Debug",
+        3 | _ => "Trace",
+    };
+    env_logger::init_from_env(
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, min_log_level),
+    );
+    trace!("Program was called with CLI 😉");
     trace!("Parsed the arguments");
     println!("{:?}", opts.text);
     println!("{:?}", opts.verbose);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use ares::perform_cracking;
 mod cli_input_parser;
 
 use clap::Parser;
-use env_logger;
 
 use log::trace;
 


### PR DESCRIPTION
Fixed verbose mode by adding `env_logger` and now verbose flags work. There are 3 levels. By default it logs the `Error` and `Warn` levels. `-v` is `Info`, `-vv` is `Debug`, etc.
```rust
0 => "Warn",
1 => "Info",
2 => "Debug",
3 | _ => "Trace",
```