### PR TITLE
Enable GitHub Actions to use Git Large File Storage

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+        with:
+          lfs: true
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
As part of this PR:
https://github.com/bee-san/Ares/pull/28

A bug occured whereby it did not find the word `naruto` in the dictionary.

This is likely because the action by default does not download LFS objects. This PR enables that according to:
https://github.com/actions/checkout