### PR TITLE
Add documentation to Ares

### DIFF
--- a/src/api_library_input_struct.rs
+++ b/src/api_library_input_struct.rs
@@ -20,6 +20,7 @@ pub struct LibraryInput<Type> {
     pub lemmeknow_config: Identify,
 }
 
+/// Creates a default lemmeknow config
 const LEMMEKNOW_DEFAULT_CONFIG: Identify = Identify {
     min_rarity: None,
     max_rarity: None,

--- a/src/checkers/checker_result.rs
+++ b/src/checkers/checker_result.rs
@@ -1,5 +1,6 @@
 use super::checker_type::Checker;
 
+/// The checkerResult struct is used to store the results of a checker.
 pub struct CheckResult {
     /// If our checkers return success, we change this bool to True
     pub is_identified: bool,
@@ -23,6 +24,7 @@ pub struct CheckResult {
 /// as we will not use it. To save time we will return a default
 /// checker.
 impl CheckResult {
+    /// Creates a default CheckResult
     pub fn new<Type>(checker_used: &Checker<Type>) -> CheckResult {
         CheckResult {
             is_identified: false,

--- a/src/checkers/checker_type.rs
+++ b/src/checkers/checker_type.rs
@@ -25,6 +25,8 @@ pub struct Checker<Type> {
     pub popularity: f32,
     /// lemmeknow config object
     pub lemmeknow_config: Identify,
+    /// https://doc.rust-lang.org/std/marker/struct.PhantomData.html
+    /// Let's us save code lines when we don't need to use a type parameter
     pub _phatom: std::marker::PhantomData<Type>,
 }
 
@@ -32,6 +34,8 @@ pub struct Checker<Type> {
 /// Which checks the given text to see if its plaintext
 /// and returns CheckResult, which is our results object.
 pub trait Check {
+    /// Returns a new struct of type CheckerType
     fn new() -> Self;
+    /// Checks the given text to see if its plaintext
     fn check(&self, text: &str) -> CheckResult;
 }

--- a/src/checkers/checker_type.rs
+++ b/src/checkers/checker_type.rs
@@ -26,7 +26,10 @@ pub struct Checker<Type> {
     /// lemmeknow config object
     pub lemmeknow_config: Identify,
     /// https://doc.rust-lang.org/std/marker/struct.PhantomData.html
-    /// Let's us save code lines when we don't need to use a type parameter
+    /// Let's us save memory by telling the compiler that our type
+    /// acts like a type <T> even though it doesn't.
+    /// Stops the compiler complaining, else we'd need to implement
+    /// some magic to make it work.
     pub _phatom: std::marker::PhantomData<Type>,
 }
 

--- a/src/checkers/english.rs
+++ b/src/checkers/english.rs
@@ -6,6 +6,7 @@ use lemmeknow::Identify;
 
 use crate::checkers::checker_type::{Check, Checker};
 
+/// Checks English plaintext.
 pub struct EnglishChecker;
 
 /// given an input, check every item in the array and return true if any of them match

--- a/src/checkers/human_checker.rs
+++ b/src/checkers/human_checker.rs
@@ -3,6 +3,10 @@ use crate::checkers::checker_result::CheckResult;
 #[cfg(not(test))]
 use text_io::read;
 
+/// The Human Checker asks humans if the expected plaintext is real plaintext
+/// We can use all the automated checkers in the world, but sometimes they get false positives
+/// Humans have the last say.
+/// TODO: Add a way to specify a list of checkers to use in the library. This checker is not library friendly!
 // compile this if we are not running tests
 #[cfg(not(test))]
 pub fn human_checker(input: &CheckResult) -> bool {

--- a/src/checkers/lemmeknow_checker.rs
+++ b/src/checkers/lemmeknow_checker.rs
@@ -3,6 +3,7 @@ use lemmeknow::{Data, Identify};
 
 use super::checker_type::{Check, Checker};
 
+/// The Lemmeknow checker configuration struct
 const IDENTIFIER: Identify = Identify {
     min_rarity: None,
     max_rarity: None,
@@ -12,6 +13,8 @@ const IDENTIFIER: Identify = Identify {
     boundaryless: false,
 };
 
+/// The LemmeKnow Checker checks if the text matches a known Regex pattern.
+/// This is the struct for it.
 pub struct LemmeKnow;
 
 impl Check for Checker<LemmeKnow> {
@@ -50,6 +53,8 @@ impl Check for Checker<LemmeKnow> {
     }
 }
 
+/// Formats the data result to a string
+/// This is used to display the result in the UI
 fn format_data_result(input: &Data) -> String {
     /*
     Input contains these:

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -4,17 +4,34 @@ use self::{
     lemmeknow_checker::LemmeKnow,
 };
 
+/// The checkerResult struct is used to store the results of a checker.
 mod checker_result;
+/// This is the base checker that all other checkers inherit from.
 pub mod checker_type;
+/// The default checker we use which simply calls all other checkers in order.
 pub mod default_checker;
+/// The English Checker is a checker that checks if the input is English
 mod english;
+/// The Human Checker asks humans if the expected plaintext is real plaintext
 pub mod human_checker;
+/// The LemmeKnow Checker checks if the text matches a known Regex pattern.
 mod lemmeknow_checker;
 
+/// The default checker we use which simply calls all other checkers in order.
 trait GeneralChecker {
+    /// Checks the given text to see if its plaintext
     fn check(&self, input: &str) -> bool;
 }
 
+/// The main function to call which performs the checking.
+/// This function calls all other checkers in order to check if the input is plaintext.
+/// ```rust
+/// use ares::checkers::check;
+/// let plaintext = check("hello");
+/// let plaintext_ip = check("192.168.0.1");
+/// assert!(plaintext);
+/// assert!(plaintext_ip);
+/// ```
 pub fn check(input: &str) -> bool {
     // Uses lemmeknow to check if any regexes match
     // import and call lemmeknow.rs

--- a/src/cli_input_parser/mod.rs
+++ b/src/cli_input_parser/mod.rs
@@ -10,7 +10,8 @@ and so on.
 
 use crate::api_library_input_struct::LibraryInput;
 
-// added _ before name to let clippy know that they aren't used
+/// This creates a new LibraryInput struct and sets it to a default.
+/// added _ before name to let clippy know that they aren't used
 fn _main() {
     let _options = LibraryInput::default();
 }

--- a/src/decoders/base64_decoder.rs
+++ b/src/decoders/base64_decoder.rs
@@ -65,7 +65,7 @@ impl Crack for Decoder<Base64Decoder> {
     }
 }
 
-// helper function
+/// helper function
 fn decode_base64_no_error_handling(text: &str) -> Option<String> {
     // Runs the code to decode base64
     // Doesn't perform error handling, call from_base64

--- a/src/decoders/interface.rs
+++ b/src/decoders/interface.rs
@@ -1,12 +1,18 @@
 ///! The Interface defines what the struct for each decoder looks like
 //TODO: rename this file
 pub struct Decoder<Type> {
+    /// The English name of the decoder.
     pub name: &'static str,
     /// A description, you can take the first line from Wikipedia
     /// Sometimes our decoders do not exist on Wikipedia so we write our own.
     pub description: &'static str,
     /// Wikipedia Link
     pub link: &'static str,
+    /// The tags it has. See other decoders. Think of it as a "category"
+    /// This is used to filter decoders.
+    /// For example, if you want to filter decoders that are "base64"
+    /// you would use the tag "base64" or "base".
+    /// You can also add tags like "online" to filter decoders that are online.
     pub tags: Vec<&'static str>,
     /// We get expectedRuntime this by bench marking the code
     pub expected_runtime: f32,
@@ -19,12 +25,12 @@ pub struct Decoder<Type> {
     /// Expected is how long we expect, if it fails completely
     /// This is how long it'll take to fail.
     pub failure_runtime: f32,
-    // normalised_entropy is the range of entropy for this
-    // So base64's normalised entropy might be between 2.5 and 3
-    // This allows us to decide whether it's worth decoding
-    // If current text has entropy 9, it's unlikey to be base64
+    /// normalised_entropy is the range of entropy for this
+    /// So base64's normalised entropy might be between 2.5 and 3
+    /// This allows us to decide whether it's worth decoding
+    /// If current text has entropy 9, it's unlikey to be base64
     pub normalised_entropy: Vec<f32>,
-    // we don't use the Type, so we use PhantomData to mark it!
+    /// we don't use the Type, so we use PhantomData to mark it!
     pub phantom: std::marker::PhantomData<Type>,
 }
 
@@ -33,9 +39,11 @@ pub struct Decoder<Type> {
 /// Running `.crack()` on each of them.
 /// Relevant docs: https://docs.rs/crack/0.3.0/crack/trait.Crack.html
 pub trait Crack {
+    /// This function generates a new crack trait
     fn new() -> Self
     where
         Self: Sized;
+    /// Crack is the function that actually does the decoding
     fn crack(&self, text: &str) -> Option<String>;
 }
 

--- a/src/decoders/mod.rs
+++ b/src/decoders/mod.rs
@@ -5,6 +5,15 @@
 //! mod.rs file
 //! you will also need to make it a public module in this file.
 
+/// The base64_decoder module decodes base64
+/// It is public as we use it in some tests.
 pub mod base64_decoder;
+
+/// The interface module defines the interface for decoders
+/// Each and every decoder has the same struct & traits
 pub mod interface;
+
+/// The reverse_decoder module decodes reverse text
+/// Stac -> Cats
+/// It is public as we use it in some tests.
 pub mod reverse_decoder;

--- a/src/decoders/reverse_decoder.rs
+++ b/src/decoders/reverse_decoder.rs
@@ -7,7 +7,14 @@ use super::interface::Crack;
 use super::interface::Decoder;
 
 use log::trace;
-
+/// The Reverse decoder is a decoder that reverses the input string.
+/// ```rust
+/// use ares::decoders::reverse_decoder::ReverseDecoder;
+/// use ares::decoders::interface::{Crack, Decoder};
+/// let reversedecoder = Decoder::<ReverseDecoder>::new();
+/// let result = reversedecoder.crack("stac").unwrap();
+/// assert_eq!(result, "cats");
+/// ```
 pub struct ReverseDecoder;
 
 impl Crack for Decoder<ReverseDecoder> {
@@ -17,8 +24,10 @@ impl Crack for Decoder<ReverseDecoder> {
             description: "Reverses a string. stac -> cats",
             link: "http://string-functions.com/reverse.aspx",
             tags: vec!["reverse", "decoder"],
+            /// We expect it to take 0.01 seconds to run
             expected_runtime: 0.01,
             expected_success: 1.0,
+            /// If it was to fail, we'd expect it to take 0.01 seconds
             failure_runtime: 0.01,
             normalised_entropy: vec![1.0, 10.0],
             // I have never seen a reversed string in a CTF

--- a/src/filtration_system/mod.rs
+++ b/src/filtration_system/mod.rs
@@ -15,6 +15,7 @@ use rayon::prelude::*;
 /// the Decoders for the Crack trait in action.
 /// Relevant docs: https://doc.rust-lang.org/book/ch17-02-trait-objects.html
 pub struct Decoders {
+    /// Components is a vector of decoders.
     pub components: Vec<Box<dyn Crack + Sync>>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,13 @@
 //! Ares is an automatic decoding and cracking tool.
+//! https://github.com/bee-san/ares
+
+// Warns in case we forget to include documentation
+#![warn(
+    missing_docs,
+    clippy::missing_docs_in_private_items,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc
+)]
 
 mod api_library_input_struct;
 mod checkers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,23 @@
     clippy::missing_panics_doc
 )]
 
+/// The main crate for the Ares project.
+/// This provides the library API interface for Ares.
 mod api_library_input_struct;
-mod checkers;
+/// Checkers is a module that contains the functions that check if the input is plaintext
+pub mod checkers;
+/// CLI Input Parser parses the input from the CLI and returns a struct.
 mod cli_input_parser;
+/// Decoders are the functions that actually perform the decodings.
 pub mod decoders;
+/// The filtration system builds what decoders to use at runtime
+/// By default it will use them all.
 mod filtration_system;
+/// The searcher is the thing which searches for the plaintext
+/// It is the core of the program.
 mod searchers;
+/// The storage module contains all the dictionaries and provides
+/// storage of data to our decoderrs and checkers.
 mod storage;
 
 /// The main function to call which performs the cracking.

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,6 +1,9 @@
 use log::trace;
 use std::collections::HashSet;
 
+
+/// Breadth first search is our search algorithm
+/// https://en.wikipedia.org/wiki/Breadth-first_search
 pub fn bfs(input: &str) -> Option<String> {
     let mut seen_strings = HashSet::new();
     // all strings to search through

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,7 +1,6 @@
 use log::trace;
 use std::collections::HashSet;
 
-
 /// Breadth first search is our search algorithm
 /// https://en.wikipedia.org/wiki/Breadth-first_search
 pub fn bfs(input: &str) -> Option<String> {

--- a/src/searchers/mod.rs
+++ b/src/searchers/mod.rs
@@ -5,6 +5,8 @@
 
 use crate::checkers;
 use crate::filtration_system::filter_and_get_decoders;
+/// This module provides access to the breadth first search
+/// which searches for the plaintext.
 mod bfs;
 
 /*pub struct Tree <'a> {
@@ -28,15 +30,15 @@ pub fn search_for_plaintext(input: &str) -> Option<String> {
     bfs::bfs(input)
 }
 
-// Performs the decodings by getting all of the decoders
-// and calling `.run` which in turn loops through them and calls
-// `.crack()`.
+/// Performs the decodings by getting all of the decoders
+/// and calling `.run` which in turn loops through them and calls
+/// `.crack()`.
 fn perform_decoding(text: &str) -> Vec<Option<String>> {
     let decoders = filter_and_get_decoders();
     decoders.run(text)
 }
 
-// https://github.com/bee-san/Ares/pull/14/files#diff-b8829c7e292562666c7fa5934de7b478c4a5de46d92e42c46215ac4d9ff89db2R37
+/// https://github.com/bee-san/Ares/pull/14/files#diff-b8829c7e292562666c7fa5934de7b478c4a5de46d92e42c46215ac4d9ff89db2R37
 fn exit_condition(input: &str) -> bool {
     // use mod.rs from checkers module
     // call check(input)

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,7 +4,11 @@ use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
+/// Tells Rust to load the dictionaries into the binary
+/// at compile time. Which means that we do not waste
+/// time loading them at runtime.
 pub static DICTIONARIES: Lazy<HashMap<&str, HashSet<&str>>> = Lazy::new(|| {
+    /// The directory where our dictionaries are stored.
     static DICTIONARIES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/src/storage/dictionaries");
     let mut entries = HashMap::new();
 


### PR DESCRIPTION
In this PR I add the following to the library:

```
    missing_docs,
    clippy::missing_docs_in_private_items,
    clippy::missing_errors_doc,
    clippy::missing_panics_doc
)]
```

This enforces that most things have documentation around them. I have fixed the errors and we will be enforcing documentation on things :)