### PR TITLE
feat: new bfs for exiting early

### DIFF
--- a/src/filtration_system/mod.rs
+++ b/src/filtration_system/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc::channel;
+
 use crate::checkers::CheckerTypes;
 ///! Proposal: https://broadleaf-angora-7db.notion.site/Filtration-System-7143b36a42f1466faea3077bfc7e859e
 ///! Given a filter object, return an array of decoders/crackers which have been filtered
@@ -23,18 +25,62 @@ pub struct Decoders {
 
 impl Decoders {
     /// Iterate over all of the decoders and run .crack(text) on them
-    /// Then turn the map into an iterator and collect into a vector of
-    /// <Vec<Option<String>>>
+    /// Then if the checker succeed, we short-circuit the iterator
+    /// and stop all processing as soon as possible.
     /// We are using Trait Objects
     /// https://doc.rust-lang.org/book/ch17-02-trait-objects.html
     /// Which allows us to have multiple different structs in the same vector
     /// But each struct shares the same `.crack()` method, so it's fine.
-    pub fn run(&self, text: &str, checker: CheckerTypes) -> Vec<CrackResult> {
+    pub fn run(&self, text: &str, checker: CheckerTypes) -> MyResults {
         trace!("Running .crack() on all decoders");
+        let (sender, receiver) = channel();
         self.components
             .into_par_iter()
-            .map(|i| i.crack(text, &checker))
-            .collect()
+            .try_for_each_with(sender, |s, i| {
+                let results = i.crack(text, &checker);
+                if results.success {
+                    s.send(results).expect("expected no send error!");
+                    // returning None short-circuits the iterator
+                    // we don't process any further as we got success
+                    return None;
+                }
+                s.send(results).expect("expected no send error!");
+                // return Some(()) to indicate that continue processing
+                Some(())
+            });
+
+        let mut all_results: Vec<CrackResult> = Vec::new();
+
+        while let Ok(result) = receiver.recv() {
+            // if we recv success, break.
+            if result.success {
+                return MyResults::Break(result);
+            }
+            all_results.push(result)
+        }
+
+        MyResults::Continue(all_results)
+    }
+}
+
+/// [`Enum`] for our custom results.
+/// if our checker succeed, we return `Break` variant contining [`CrackResult`]
+/// else we return `Continue` with the decoded results.
+pub enum MyResults {
+    /// Variant containing successful [`CrackResult`]
+    Break(CrackResult),
+    /// Contains [`Vec`] of [`CrackResult`] for further processing
+    Continue(Vec<CrackResult>),
+}
+
+impl MyResults {
+    /// named with _ to pass dead_code warning
+    /// as we aren't using it, it's just used in tests
+    pub fn _break_value(self) -> Option<CrackResult> {
+        match self {
+            MyResults::Break(val) => Some(val),
+            MyResults::Continue(_) => None,
+        }
     }
 }
 

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,6 +1,8 @@
 use log::trace;
 use std::collections::HashSet;
 
+use crate::{decoders::crack_results::CrackResult, filtration_system::MyResults};
+
 /// Breadth first search is our search algorithm
 /// https://en.wikipedia.org/wiki/Breadth-first_search
 pub fn bfs(input: &str) -> Option<String> {
@@ -8,32 +10,47 @@ pub fn bfs(input: &str) -> Option<String> {
     // all strings to search through
     let mut current_strings = vec![input.to_string()];
 
+    let mut exit_result: Option<CrackResult> = None;
+
     // loop through all of the strings in the vec
     while !current_strings.is_empty() {
         trace!("Number of potential decodings: {}", current_strings.len());
 
-        // runs the decodings and puts it into
-        let all_results: Vec<_> = current_strings
+        let mut new_strings: Vec<String> = vec![];
+
+        current_strings
             .into_iter()
-            .flat_map(|current_string| super::perform_decoding(&current_string))
-            .filter(|elem| seen_strings.insert(elem.unencrypted_text.clone()))
-            .collect();
+            .map(|current_string| super::perform_decoding(&current_string))
+            .try_for_each(|elem| match elem {
+                // if it's Break variant, we have cracked the text successfully
+                // so just stop processing further.
+                MyResults::Break(res) => {
+                    exit_result = Some(res);
+                    None // short-circuits the iterator
+                }
+                MyResults::Continue(results_vec) => {
+                    new_strings = results_vec
+                        .into_iter()
+                        .flat_map(|r| r.unencrypted_text)
+                        .filter(|s| seen_strings.insert(s.clone()))
+                        .collect();
+                    Some(()) // indicate we want to continue processing
+                }
+            });
 
         // if we find an element that matches our exit condition, return it!
         // technically this won't check if the initial string matches our exit condition
         // but this is a demo and i'll be lazy :P
-        if let Some(exit_res) = all_results.iter().find(|elem| elem.success) {
+        if let Some(exit_res) = exit_result {
             let exit_str = exit_res
                 .unencrypted_text
-                .clone()
                 .expect("No unencrypted text even after checker succeed!");
             trace!("Found exit string: {}", exit_str);
             return Some(exit_str);
         }
-        current_strings = all_results
-            .iter()
-            .filter_map(|res| res.unencrypted_text.clone())
-            .collect();
+
+        current_strings = new_strings;
+
         trace!("Refreshed the vector, {:?}", current_strings);
     }
 

--- a/src/searchers/mod.rs
+++ b/src/searchers/mod.rs
@@ -6,8 +6,7 @@
 use crate::checkers::athena::Athena;
 use crate::checkers::checker_type::{Check, Checker};
 use crate::checkers::CheckerTypes;
-use crate::decoders::crack_results::CrackResult;
-use crate::filtration_system::filter_and_get_decoders;
+use crate::filtration_system::{filter_and_get_decoders, MyResults};
 /// This module provides access to the breadth first search
 /// which searches for the plaintext.
 mod bfs;
@@ -36,7 +35,7 @@ pub fn search_for_plaintext(input: &str) -> Option<String> {
 /// Performs the decodings by getting all of the decoders
 /// and calling `.run` which in turn loops through them and calls
 /// `.crack()`.
-fn perform_decoding(text: &str) -> Vec<CrackResult> {
+fn perform_decoding(text: &str) -> MyResults {
     let decoders = filter_and_get_decoders();
     let athena_checker = Checker::<Athena>::new();
     let checker = CheckerTypes::CheckAthena(athena_checker);
@@ -71,14 +70,18 @@ mod tests {
     #[test]
     fn perform_decoding_succeeds() {
         let result = perform_decoding("aHR0cHM6Ly93d3cuZ29vZ2xlLmNvbQ==");
-        assert!(!result.is_empty());
-        assert!(result.get(0).is_some());
+        assert!(
+            result
+                ._break_value()
+                .expect("expected successful value, none found")
+                .success
+        );
         //TODO assert that the plaintext is correct by looping over the vector
     }
     #[test]
     fn perform_decoding_succeeds_empty_string() {
         // Some decoders like base64 return even when the string is empty.
         let result = perform_decoding("");
-        assert!(!result.is_empty());
+        assert!(result._break_value().is_none());
     }
 }


### PR DESCRIPTION
We want to exit early if we have successfully decoded the text, this means we should stop calling other decoders after getting success as soon as possible!

To achieve this, without using `for loops` and having `par_iter`, we call `try_for_each_with` instead of `map` . we use `channels` to get our results. If we get success, we return `None` which _attempts_ to stop the iterator ASAP!
```rust
 self.components
            .into_par_iter()
            .try_for_each_with(sender, |s, i| {
                let results = i.crack(text, &checker);
                if results.success {
                    s.send(results).expect("expected no send error!");
                    // returning None short-circuits the iterator
                    // we don't process any further as we got success
                    return None;
                }
                s.send(results).expect("expected no send error!");
                // return Some(()) to indicate that continue processing
                Some(())
            });
```

We now stop calling `.crack()` on other decoders when we get `success`, but it would be great if our bfs can exit early too right?

Therefore we use our custom results `MyResult`
```rust
pub enum MyResults {
    // return this if sucess
    Break(CrackResult),
    // else return all crack results
    Continue(Vec<CrackResult>),
}
```

And then inside `bfs`, if we encounter `MyResult::Break`, we know we have successfully decoded the text, so we use the same logic of `try_for_each` to short-circuit the iterator and exit early.
```rust
current_strings
            .into_iter()
            .map(|current_string| super::perform_decoding(&current_string))
            .try_for_each(|elem| match elem {
                // if it's Break variant, we have cracked the text successfully
                // so just stop processing further.
                MyResults::Break(res) => {
                    exit_result = Some(res);
                    None // short-circuits the iterator
                }
                MyResults::Continue(results_vec) => {
                    new_strings = results_vec
                        .into_iter()
                        .flat_map(|r| r.unencrypted_text)
                        .filter(|s| seen_strings.insert(s.clone()))
                        .collect();
                    Some(()) // indicate we want to continue processing
                }
            });
```
This also means that we won't have to iterate over all results again to see if any of them was successful!