### PR TITLE
timer in bfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +218,16 @@ dependencies = [
  "memoffset",
  "once_cell",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -527,6 +551,7 @@ dependencies = [
  "base64",
  "clap 3.2.12",
  "criterion",
+ "crossbeam",
  "env_logger",
  "include_dir",
  "lemmeknow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ lemmeknow = { git = "https://github.com/swanandx/lemmeknow", default-features = 
 include_dir = "0.7.2"
 once_cell = "1.13.0"
 text_io = "0.1.10"
+crossbeam = "0.8.2"
 
 [dev-dependencies]
 criterion = "0.3.6"

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,7 +1,15 @@
 use log::trace;
 use std::collections::HashSet;
+use std::time::Duration;
 
-use crate::{decoders::crack_results::CrackResult, filtration_system::MyResults};
+use crate::filtration_system::MyResults;
+use crossbeam::{
+    channel::{after, bounded},
+    select,
+};
+
+/// Maximum duration for which we try to decoded text
+const TIMEOUT_DURATION: Duration = Duration::from_secs(60);
 
 /// Breadth first search is our search algorithm
 /// https://en.wikipedia.org/wiki/Breadth-first_search
@@ -10,7 +18,12 @@ pub fn bfs(input: &str) -> Option<String> {
     // all strings to search through
     let mut current_strings = vec![input.to_string()];
 
-    let mut exit_result: Option<CrackResult> = None;
+    // sender and receiver for exit result.
+    // It has capacity of 1 as there will only be one successful result.
+    let (result_sender, result_receiver) = bounded(1);
+
+    // this will send after duration
+    let timeout = after(TIMEOUT_DURATION);
 
     // loop through all of the strings in the vec
     while !current_strings.is_empty() {
@@ -25,7 +38,9 @@ pub fn bfs(input: &str) -> Option<String> {
                 // if it's Break variant, we have cracked the text successfully
                 // so just stop processing further.
                 MyResults::Break(res) => {
-                    exit_result = Some(res);
+                    result_sender
+                        .send(res)
+                        .expect("expected no send error while sending exit result");
                     None // short-circuits the iterator
                 }
                 MyResults::Continue(results_vec) => {
@@ -41,15 +56,27 @@ pub fn bfs(input: &str) -> Option<String> {
         // if we find an element that matches our exit condition, return it!
         // technically this won't check if the initial string matches our exit condition
         // but this is a demo and i'll be lazy :P
-        if let Some(exit_res) = exit_result {
-            let exit_str = exit_res
-                .unencrypted_text
-                .expect("No unencrypted text even after checker succeed!");
-            trace!("Found exit string: {}", exit_str);
-            return Some(exit_str);
-        }
-
         current_strings = new_strings;
+
+        select! {
+            recv(result_receiver) -> exit_result => {
+                if let Ok(exit_res) = exit_result {
+                    let exit_str = exit_res
+                        .unencrypted_text
+                        .expect("No unencrypted text even after checker succeed!");
+                    trace!("Found exit string: {}", exit_str);
+                    return Some(exit_str)
+                }
+            },
+            recv(timeout) -> _ => {
+                trace!("Timed out after {}s", TIMEOUT_DURATION.as_secs());
+                // instead of returning None, we can change return type of bfs
+                // to Result<Option<String>, TimeOutError>
+                // and then we can return TimeOutError here ( it can be a String too)
+                return None
+            },
+            default => continue,
+        }
 
         trace!("Refreshed the vector, {:?}", current_strings);
     }


### PR DESCRIPTION
This adds a Timer in bfs function.

 we can change the timeout using this constant
```rust
/// Maximum duration for which we try to decoded text
const TIMEOUT_DURATION: Duration = Duration::from_secs(60);
```

we use `crossbeam` crate for channels and other cool stuff like `select!`.
```rust
select! {
            recv(result_receiver) -> exit_result => {
                if let Ok(exit_res) = exit_result {
                    let exit_str = exit_res
                        .unencrypted_text
                        .expect("No unencrypted text even after checker succeed!");
                    trace!("Found exit string: {}", exit_str);
                    return Some(exit_str)
                }
            },
            recv(timeout) -> _ => {
                trace!("Timed out after {}s", TIMEOUT_DURATION.as_secs());
                // instead of returning None, we can change return type of bfs
                // to Result<Option<String>, TimeOutError>
                // and then we can return TimeOutError here ( it can be a String too)
                return None
            },
            default => continue,
        }
```
It runs the code based on if our `receiver` received something, else it runs code in `default`.

We use a special channel from `crossbeam` called `after` which delivers a single message after a certain duration of time.
```rust
// this will send after duration
    let timeout = after(TIMEOUT_DURATION);
```

NOTE: for testing, either call sleep in some decoder to get timeout, or set timeout to something very short like `const TIMEOUT_DURATION: Duration = Duration::from_micros(60)` 