### PR TITLE
fix: fixed a bug in new_strings

### DIFF
--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -74,8 +74,15 @@ mod tests {
         assert!(result.unwrap() == "hello");
     }
 
+    // Vector storing the strings to perform decoding in next iteraion
+    // had strings only from result of last decoding it performed.
+    // This was due to reassignment in try_for_each block
+    // which lead to unintended behaviour.
+    // We want strings from all results, so to fix it,
+    // we call .extend() to extend the vector.
+    // Link to forum https://discord.com/channels/754001738184392704/1002135076034859068
     #[test]
-    fn new_strings_works() {
+    fn non_deterministic_like_behaviour_regression_test() {
         // text was too long, so we put \ to escape the \n
         // and put the rest of string on next line.
         let result = bfs("UFRCRVRWVkNiRlZMTVVkYVVFWjZVbFZPU0\

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -73,4 +73,14 @@ mod tests {
         assert!(result.is_some());
         assert!(result.unwrap() == "hello");
     }
+
+    #[test]
+    fn new_strings_works() {
+        // text was too long, so we put \ to escape the \n
+        // and put the rest of string on next line.
+        let result = bfs("UFRCRVRWVkNiRlZMTVVkYVVFWjZVbFZPU0\
+        dGMU1WVlpZV2d4VkRVNWJWWnJjRzFVUlhCc1pYSlNWbHBPY0VaV1ZXeHJWRWd4TUZWdlZsWlg=");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), "https://www.google.com");
+    }
 }

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -29,11 +29,12 @@ pub fn bfs(input: &str) -> Option<String> {
                     None // short-circuits the iterator
                 }
                 MyResults::Continue(results_vec) => {
-                    new_strings = results_vec
-                        .into_iter()
-                        .flat_map(|r| r.unencrypted_text)
-                        .filter(|s| seen_strings.insert(s.clone()))
-                        .collect();
+                    new_strings.extend(
+                        results_vec
+                            .into_iter()
+                            .flat_map(|r| r.unencrypted_text)
+                            .filter(|s| seen_strings.insert(s.clone())),
+                    );
                     Some(()) // indicate we want to continue processing
                 }
             });


### PR DESCRIPTION
The bug was caused by reassigning `new_strings` inside a `try_for_each` block.

```rust
new_strings = results_vec
        .into_iter()
        .flat_map(|r| r.unencrypted_text)
        .filter(|s| seen_strings.insert(s.clone()))
        .collect();
```
This was overwriting the content of `new_strings` with the strings from `result_vec` of the last result it got from running decoders. This isn't intended. we want strings from all results.

Therefore, we use `.extend` to _extend_ our `new_strings` with the strings from each `result_vec`
```rust
new_strings.extend(
        results_vec
            .into_iter()
            .flat_map(|r| r.unencrypted_text)
            .filter(|s| seen_strings.insert(s.clone())),
    );
```

Link to [Discussion](https://discord.com/channels/754001738184392704/1002135076034859068/1002135076034859068)