### PR TITLE
Remove `panic=abort` from release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ criterion = "0.3.6"
 
 [profile.release]
 lto = "fat"
-panic = "abort"
 strip = "symbols"
 
 [[bench]]


### PR DESCRIPTION
Having this in reduces the binary size but produces less readable panics for our users. We are trying to optimise speed, having errors which unwind the stack will be useful for us.
https://doc.bccnsoft.com/docs/rust-1.36.0-docs-html/edition-guide/rust-2018/error-handling-and-panics/aborting-on-panic.html