### PR TITLE
feat: config gets initialized to default if it wasn't set

### DIFF
--- a/benches/benchmark_crackers.rs
+++ b/benches/benchmark_crackers.rs
@@ -1,13 +1,11 @@
 use ares::checkers::athena::Athena;
 use ares::checkers::checker_type::{Check, Checker};
 use ares::checkers::CheckerTypes;
-use ares::config::{set_global_config, Config};
 use ares::decoders::base64_decoder::Base64Decoder;
 use ares::decoders::interface::{Crack, Decoder};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    set_global_config(Config::default());
     let decode_base64 = Decoder::<Base64Decoder>::new();
     let athena_checker = Checker::<Athena>::new();
     let checker = CheckerTypes::CheckAthena(athena_checker);

--- a/src/checkers/human_checker.rs
+++ b/src/checkers/human_checker.rs
@@ -1,5 +1,5 @@
 use crate::checkers::checker_result::CheckResult;
-use crate::config::CONFIG;
+use crate::config::get_config;
 use text_io::read;
 
 /// The Human Checker asks humans if the expected plaintext is real plaintext
@@ -9,7 +9,7 @@ use text_io::read;
 // compile this if we are not running tests
 pub fn human_checker(input: &CheckResult) -> bool {
     // wait instead of get so it waits for config being set
-    let config = CONFIG.wait();
+    let config = get_config();
     // We still call human checker, just if config is false we return True
     if !config.human_checker_on {
         return true;

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -45,25 +45,20 @@ impl CheckerTypes {
 // test
 #[cfg(test)]
 mod tests {
-    use crate::{
-        checkers::{
-            athena::Athena,
-            checker_type::{Check, Checker},
-            CheckerTypes,
-        },
-        config::{set_global_config, Config},
+    use crate::checkers::{
+        athena::Athena,
+        checker_type::{Check, Checker},
+        CheckerTypes,
     };
 
     #[test]
     fn test_check_ip_address() {
-        set_global_config(Config::default());
         let athena = CheckerTypes::CheckAthena(Checker::<Athena>::new());
         assert!(athena.check("192.168.0.1").is_identified);
     }
 
     #[test]
     fn test_check_goes_to_dictionary() {
-        set_global_config(Config::default());
         let athena = CheckerTypes::CheckAthena(Checker::<Athena>::new());
         assert!(athena.check("and").is_identified);
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,10 +8,11 @@ use once_cell::sync::OnceCell;
 /// For the entire program
 /// It's access using a variable like configuration
 /// ```rust
-/// use ares::config::{CONFIG, Config, set_global_config};
-/// set_global_config(Config::default());
+/// use ares::config::get_config;
 /// // Assert that the CONFIG has an offline mode
-/// assert!(!CONFIG.wait().offline_mode);
+/// let config = get_config();
+/// assert!(!config.offline_mode);
+/// ```
 
 pub struct Config {
     /// A level of verbosity to determine.
@@ -26,13 +27,18 @@ pub struct Config {
     pub offline_mode: bool,
 }
 
-/// Global config
-pub static CONFIG: OnceCell<Config> = OnceCell::new();
+/// Cell for storing global Config
+static CONFIG: OnceCell<Config> = OnceCell::new();
 
-#[allow(unused_must_use)]
-/// To initialize global config
+/// To initialize global config with custom values
 pub fn set_global_config(config: Config) {
-    CONFIG.set(config);
+    CONFIG.set(config).ok(); // ok() used to make compiler happy about using Result
+}
+
+/// Get hthe global config.
+/// This will return default config if the config isn't initialized
+pub fn get_config() -> &'static Config {
+    CONFIG.get_or_init(Config::default)
 }
 
 /// Creates a default lemmeknow config

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -35,8 +35,8 @@ pub fn set_global_config(config: Config) {
     CONFIG.set(config).ok(); // ok() used to make compiler happy about using Result
 }
 
-/// Get hthe global config.
-/// This will return default config if the config isn't initialized
+/// Get the global config.
+/// This will return default config if the config wasn't already initialized
 pub fn get_config() -> &'static Config {
     CONFIG.get_or_init(Config::default)
 }

--- a/src/decoders/base64_decoder.rs
+++ b/src/decoders/base64_decoder.rs
@@ -20,14 +20,11 @@ use log::{debug, info, trace};
 /// ```
 /// use ares::decoders::base64_decoder::{Base64Decoder};
 /// use ares::decoders::interface::{Crack, Decoder};
-/// use ares::config::{set_global_config, Config};
 /// use ares::checkers::{athena::Athena, CheckerTypes, checker_type::{Check, Checker}};
 ///
 /// let decode_base64 = Decoder::<Base64Decoder>::new();
 /// let athena_checker = Checker::<Athena>::new();
 /// let checker = CheckerTypes::CheckAthena(athena_checker);
-/// // set global config
-/// set_global_config(Config::default());
 ///
 /// let result = decode_base64.crack("aGVsbG8gd29ybGQ=", &checker).unencrypted_text;
 /// assert!(result.is_some());

--- a/src/decoders/reverse_decoder.rs
+++ b/src/decoders/reverse_decoder.rs
@@ -20,8 +20,6 @@ use log::trace;
 /// let reversedecoder = Decoder::<ReverseDecoder>::new();
 /// let athena_checker = Checker::<Athena>::new();
 /// let checker = CheckerTypes::CheckAthena(athena_checker);
-/// // set global config
-/// set_global_config(Config::default());
 ///
 /// let result = reversedecoder.crack("stac", &checker).unencrypted_text;
 /// assert!(result.is_some());


### PR DESCRIPTION
we can use `get_config` to get the global config.
```rust
let config = get_config();
```
If we have set the config already using `set_global_config()`, it will return reference to it, else it will initialize the config to default and reference return it.

This means we no more need to set global config every time.
```rust
// set global config
set_global_config(Config::default()); // no need for this
```
