### PR TITLE
Simple counter to stop the searcher when max depth is reached

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,7 +22,7 @@ pub struct Opts {
     disable_human_checker: bool,
 
     /// Maximum number of decodings to perform on a string
-    #[clap(short, long, default_value="10000")]
+    #[clap(short, long, default_value = "10000")]
     max_depth: u32,
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -58,7 +58,7 @@ fn cli_args_into_config_struct(opts: Opts) -> (String, Config) {
             // default is false, we want default to be true
             human_checker_on: !opts.disable_human_checker,
             offline_mode: true,
-            max_depth: opts.max_depth,
+            max_depth: Some(opts.max_depth),
         },
     )
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -20,6 +20,10 @@ pub struct Opts {
     /// Turn off human checker
     #[clap(short, long)]
     disable_human_checker: bool,
+
+    /// Maximum number of decodings to perform on a string
+    #[clap(short, long, default_value="10000")]
+    max_depth: u32,
 }
 
 /// Parse CLI Arguments turns a Clap Opts struct, seen above
@@ -54,6 +58,7 @@ fn cli_args_into_config_struct(opts: Opts) -> (String, Config) {
             // default is false, we want default to be true
             human_checker_on: !opts.disable_human_checker,
             offline_mode: true,
+            max_depth: opts.max_depth,
         },
     )
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,6 +24,8 @@ pub struct Config {
     pub human_checker_on: bool,
     /// Is the program being run in offline mode?
     pub offline_mode: bool,
+    /// Number of times decoding shall be perfomed
+    pub max_depth: u32,
 }
 
 /// Global config
@@ -52,6 +54,7 @@ impl Default for Config {
             lemmeknow_config: LEMMEKNOW_DEFAULT_CONFIG,
             human_checker_on: false,
             offline_mode: false,
+            max_depth: 10_000, // TODO: Set this to some better value
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,7 +26,8 @@ pub struct Config {
     /// Is the program being run in offline mode?
     pub offline_mode: bool,
     /// Number of times decoding shall be perfomed
-    pub max_depth: u32,
+    /// Setting it to [`None`] means we will go infinitely in depth
+    pub max_depth: Option<u32>,
 }
 
 /// Cell for storing global Config
@@ -60,7 +61,7 @@ impl Default for Config {
             lemmeknow_config: LEMMEKNOW_DEFAULT_CONFIG,
             human_checker_on: false,
             offline_mode: false,
-            max_depth: 10_000, // TODO: Set this to some better value
+            max_depth: Some(10_000), // TODO: Set this to some better value
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,9 @@ pub fn perform_cracking(text: &str, config: Config) -> Option<String> {
     // let search_tree = searchers::Tree::new(text.to_string());
     // Perform the search algorithm
     // It will either return a failure or success.
+    let max_depth = config.max_depth;
     config::set_global_config(config);
-    searchers::search_for_plaintext(text)
+    searchers::search_for_plaintext(text, max_depth)
 }
 
 #[cfg(test)]

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,8 +1,9 @@
-use crate::config::CONFIG;
 use log::trace;
 use std::collections::HashSet;
 
-use crate::{decoders::crack_results::CrackResult, filtration_system::MyResults};
+use crate::{
+    config::get_config, decoders::crack_results::CrackResult, filtration_system::MyResults,
+};
 
 /// Breadth first search is our search algorithm
 /// https://en.wikipedia.org/wiki/Breadth-first_search
@@ -13,7 +14,7 @@ pub fn bfs(input: &str) -> Option<String> {
 
     let mut exit_result: Option<CrackResult> = None;
 
-    let max_depth = CONFIG.wait().max_depth;
+    let max_depth = get_config().max_depth;
 
     let mut curr_depth: u32 = 1; // as we have input string, so we start from 1
 

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -5,19 +5,17 @@ use crate::{decoders::crack_results::CrackResult, filtration_system::MyResults};
 
 /// Breadth first search is our search algorithm
 /// https://en.wikipedia.org/wiki/Breadth-first_search
-pub fn bfs(input: &str, max_depth: u32) -> Option<String> {
+pub fn bfs(input: &str, max_depth: Option<u32>) -> Option<String> {
     let mut seen_strings = HashSet::new();
     // all strings to search through
     let mut current_strings = vec![input.to_string()];
 
     let mut exit_result: Option<CrackResult> = None;
 
-    // let max_depth = get_config().max_depth;
-
     let mut curr_depth: u32 = 1; // as we have input string, so we start from 1
 
     // loop through all of the strings in the vec
-    while !current_strings.is_empty() && curr_depth <= max_depth {
+    while !current_strings.is_empty() && max_depth.map_or(true, |x| curr_depth <= x) {
         trace!("Number of potential decodings: {}", current_strings.len());
         trace!("Current depth is {:?}; [ {:?} max ]", curr_depth, max_depth);
 
@@ -74,7 +72,7 @@ mod tests {
         // let result = bfs("Q0FOQVJZOiBoZWxsbw==");
         // assert!(result.is_some());
         // assert!(result.unwrap() == "CANARY: hello");
-        let result = bfs("b2xsZWg=", 100);
+        let result = bfs("b2xsZWg=", None);
         assert!(result.is_some());
         assert!(result.unwrap() == "hello");
     }
@@ -93,7 +91,7 @@ mod tests {
         let result = bfs(
             "UFRCRVRWVkNiRlZMTVVkYVVFWjZVbFZPU0\
         dGMU1WVlpZV2d4VkRVNWJWWnJjRzFVUlhCc1pYSlNWbHBPY0VaV1ZXeHJWRWd4TUZWdlZsWlg=",
-            100,
+            None,
         );
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "https://www.google.com");
@@ -102,7 +100,7 @@ mod tests {
     #[test]
     fn max_depth_test() {
         // text is encoded with base64 5 times
-        let result = bfs("VjFaV2ExWXlUWGxUYTJoUVVrUkJPUT09", 4);
+        let result = bfs("VjFaV2ExWXlUWGxUYTJoUVVrUkJPUT09", Some(4));
         // It goes only upto depth 4, so it can't find the plaintext
         assert!(result.is_none());
     }

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -3,6 +3,8 @@ use std::collections::HashSet;
 
 use crate::{decoders::crack_results::CrackResult, filtration_system::MyResults};
 
+const MAX_DEPTH: u32 = 4;
+
 /// Breadth first search is our search algorithm
 /// https://en.wikipedia.org/wiki/Breadth-first_search
 pub fn bfs(input: &str) -> Option<String> {
@@ -12,8 +14,10 @@ pub fn bfs(input: &str) -> Option<String> {
 
     let mut exit_result: Option<CrackResult> = None;
 
+    let mut curr_depth: u32 = 1; // as we have input string, so we start from 1
+
     // loop through all of the strings in the vec
-    while !current_strings.is_empty() {
+    while !current_strings.is_empty() && curr_depth <= MAX_DEPTH {
         trace!("Number of potential decodings: {}", current_strings.len());
 
         let mut new_strings: Vec<String> = vec![];
@@ -51,6 +55,7 @@ pub fn bfs(input: &str) -> Option<String> {
         }
 
         current_strings = new_strings;
+        curr_depth += 1;
 
         trace!("Refreshed the vector, {:?}", current_strings);
     }

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,9 +1,9 @@
 use log::trace;
 use std::collections::HashSet;
+use crate::config::CONFIG;
 
 use crate::{decoders::crack_results::CrackResult, filtration_system::MyResults};
 
-const MAX_DEPTH: u32 = 4;
 
 /// Breadth first search is our search algorithm
 /// https://en.wikipedia.org/wiki/Breadth-first_search
@@ -14,11 +14,14 @@ pub fn bfs(input: &str) -> Option<String> {
 
     let mut exit_result: Option<CrackResult> = None;
 
+    let max_depth = CONFIG.wait().max_depth;
+
     let mut curr_depth: u32 = 1; // as we have input string, so we start from 1
 
     // loop through all of the strings in the vec
-    while !current_strings.is_empty() && curr_depth <= MAX_DEPTH {
+    while !current_strings.is_empty() && curr_depth <= max_depth {
         trace!("Number of potential decodings: {}", current_strings.len());
+        trace!("Current depth is {:?}; [ {:?} max ]", curr_depth, max_depth);
 
         let mut new_strings: Vec<String> = vec![];
 

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,9 +1,8 @@
+use crate::config::CONFIG;
 use log::trace;
 use std::collections::HashSet;
-use crate::config::CONFIG;
 
 use crate::{decoders::crack_results::CrackResult, filtration_system::MyResults};
-
 
 /// Breadth first search is our search algorithm
 /// https://en.wikipedia.org/wiki/Breadth-first_search

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,20 +1,18 @@
 use log::trace;
 use std::collections::HashSet;
 
-use crate::{
-    config::get_config, decoders::crack_results::CrackResult, filtration_system::MyResults,
-};
+use crate::{decoders::crack_results::CrackResult, filtration_system::MyResults};
 
 /// Breadth first search is our search algorithm
 /// https://en.wikipedia.org/wiki/Breadth-first_search
-pub fn bfs(input: &str) -> Option<String> {
+pub fn bfs(input: &str, max_depth: u32) -> Option<String> {
     let mut seen_strings = HashSet::new();
     // all strings to search through
     let mut current_strings = vec![input.to_string()];
 
     let mut exit_result: Option<CrackResult> = None;
 
-    let max_depth = get_config().max_depth;
+    // let max_depth = get_config().max_depth;
 
     let mut curr_depth: u32 = 1; // as we have input string, so we start from 1
 
@@ -76,7 +74,7 @@ mod tests {
         // let result = bfs("Q0FOQVJZOiBoZWxsbw==");
         // assert!(result.is_some());
         // assert!(result.unwrap() == "CANARY: hello");
-        let result = bfs("b2xsZWg=");
+        let result = bfs("b2xsZWg=", 100);
         assert!(result.is_some());
         assert!(result.unwrap() == "hello");
     }
@@ -92,9 +90,20 @@ mod tests {
     fn non_deterministic_like_behaviour_regression_test() {
         // text was too long, so we put \ to escape the \n
         // and put the rest of string on next line.
-        let result = bfs("UFRCRVRWVkNiRlZMTVVkYVVFWjZVbFZPU0\
-        dGMU1WVlpZV2d4VkRVNWJWWnJjRzFVUlhCc1pYSlNWbHBPY0VaV1ZXeHJWRWd4TUZWdlZsWlg=");
+        let result = bfs(
+            "UFRCRVRWVkNiRlZMTVVkYVVFWjZVbFZPU0\
+        dGMU1WVlpZV2d4VkRVNWJWWnJjRzFVUlhCc1pYSlNWbHBPY0VaV1ZXeHJWRWd4TUZWdlZsWlg=",
+            100,
+        );
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "https://www.google.com");
+    }
+
+    #[test]
+    fn max_depth_test() {
+        // text is encoded with base64 5 times
+        let result = bfs("VjFaV2ExWXlUWGxUYTJoUVVrUkJPUT09", 4);
+        // It goes only upto depth 4, so it can't find the plaintext
+        assert!(result.is_none());
     }
 }

--- a/src/searchers/mod.rs
+++ b/src/searchers/mod.rs
@@ -27,9 +27,9 @@ mod bfs;
 /// We can return an Option? An Enum? And then match on that
 /// So if we return CrackSuccess we return
 /// Else if we return an array, we add it to the children and go again.
-pub fn search_for_plaintext(input: &str) -> Option<String> {
+pub fn search_for_plaintext(input: &str, max_depth: u32) -> Option<String> {
     // Change this to select which search algorithm we want to use.
-    bfs::bfs(input)
+    bfs::bfs(input, max_depth)
 }
 
 /// Performs the decodings by getting all of the decoders

--- a/src/searchers/mod.rs
+++ b/src/searchers/mod.rs
@@ -27,7 +27,7 @@ mod bfs;
 /// We can return an Option? An Enum? And then match on that
 /// So if we return CrackSuccess we return
 /// Else if we return an array, we add it to the children and go again.
-pub fn search_for_plaintext(input: &str, max_depth: u32) -> Option<String> {
+pub fn search_for_plaintext(input: &str, max_depth: Option<u32>) -> Option<String> {
     // Change this to select which search algorithm we want to use.
     bfs::bfs(input, max_depth)
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19,3 +19,17 @@ fn test_no_panic_if_empty_string() {
     perform_cracking("", config);
     assert_eq!(true, true);
 }
+
+// To test if max depth limit is working, we set max_depth in the global config
+// Due to config being global, we don't want it to interfere with other tests, or vice-versa
+// This is why we put it in intergration_tests, as they are run independently.
+// https://doc.rust-lang.org/book/ch11-03-test-organization.html?highlight=integration#integration-tests
+#[test]
+fn max_depth_test() {
+    // text is encoded with base64 5 times
+    let mut config = Config::default();
+    config.max_depth = 4;
+    let result = perform_cracking("VjFaV2ExWXlUWGxUYTJoUVVrUkJPUT09", config);
+    // It goes only upto depth 4, so it can't find the plaintext
+    assert!(result.is_none());
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19,17 +19,3 @@ fn test_no_panic_if_empty_string() {
     perform_cracking("", config);
     assert_eq!(true, true);
 }
-
-// To test if max depth limit is working, we set max_depth in the global config
-// Due to config being global, we don't want it to interfere with other tests, or vice-versa
-// This is why we put it in intergration_tests, as they are run independently.
-// https://doc.rust-lang.org/book/ch11-03-test-organization.html?highlight=integration#integration-tests
-#[test]
-fn max_depth_test() {
-    // text is encoded with base64 5 times
-    let mut config = Config::default();
-    config.max_depth = 4;
-    let result = perform_cracking("VjFaV2ExWXlUWGxUYTJoUVVrUkJPUT09", config);
-    // It goes only upto depth 4, so it can't find the plaintext
-    assert!(result.is_none());
-}


### PR DESCRIPTION
We can set `max_depth` in global config. 
As we are exploring the graph, depth means the number of decodings we have performed so far.

This PR solves issue #37 