### PR TITLE
Add cargo-deny CI check

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -81,7 +81,7 @@ jobs:
           args: -- -D warnings
   cargo-deny:
     name: Cargo-deny
-    runs-on: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -79,3 +79,9 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+  cargo-deny:
+    name: Cargo-deny
+    runs-on: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: EmbarkStudios/cargo-deny-action@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ text_io = "0.1.10"
 data-encoding = "2.3.2"
 
 [dev-dependencies]
-criterion = "0.3.6"
+criterion = "0.4.0"
 
 [profile.release]
 lto = "fat"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,41 @@
+# cargo-deny is really only ever intended to run on the "normal" tier-1 targets
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+    { triple = "aarch64-apple-darwin" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+]
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+notice = "deny"
+unsound = "deny"
+ignore = [
+    # ansi_term is unmaintained, but it does exactly what it needs to and no more
+    # so no reason to change just for the sake of it
+    "RUSTSEC-2021-0139",
+]
+
+[licenses]
+unlicensed = "deny"
+allow-osi-fsf-free = "neither"
+copyleft = "deny"
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93
+allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "MPL-2.0"]
+
+exceptions = [
+    { allow = [
+        "Zlib",
+    ], name = "tinyvec" },
+    { allow = [
+        "Apache-2.0",
+        "BSD-2-Clause",
+    ], name = "crossbeam-queue" },
+    { allow = [
+        "Unicode-DFS-2016",
+    ], name = "unicode-ident" },
+]


### PR DESCRIPTION
Adds cargo-deny to CI to check our dependencies for advisories and license issues.