### PR TITLE
Clean up timeout function

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -58,7 +58,8 @@ fn cli_args_into_config_struct(opts: Opts) -> (String, Config) {
             // default is false, we want default to be true
             human_checker_on: !opts.disable_human_checker,
             offline_mode: true,
-            max_depth: Some(opts.max_depth),
+            // TODO make this into a CLI arg
+            timeout: 5,
         },
     )
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,9 +25,9 @@ pub struct Config {
     pub human_checker_on: bool,
     /// Is the program being run in offline mode?
     pub offline_mode: bool,
-    /// Number of times decoding shall be perfomed
-    /// Setting it to [`None`] means we will go infinitely in depth
-    pub max_depth: Option<u32>,
+    /// The timeout threshold before Ares quites
+    /// This is in seconds
+    pub timeout: u32,
 }
 
 /// Cell for storing global Config
@@ -61,7 +61,7 @@ impl Default for Config {
             lemmeknow_config: LEMMEKNOW_DEFAULT_CONFIG,
             human_checker_on: false,
             offline_mode: false,
-            max_depth: Some(10_000), // TODO: Set this to some better value
+            timeout: 5,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,8 @@ pub fn perform_cracking(text: &str, config: Config) -> Option<Text> {
     // let search_tree = searchers::Tree::new(text.to_string());
     // Perform the search algorithm
     // It will either return a failure or success.
-    let max_depth = config.max_depth;
     config::set_global_config(config);
-    searchers::search_for_plaintext(text, max_depth)
+    searchers::search_for_plaintext(text)
 }
 
 /// Our custom text which also has path to get there

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,3 +1,4 @@
+use crate::config::get_config;
 use crossbeam::{channel::bounded, select};
 use log::{error, trace};
 use std::collections::HashSet;
@@ -6,7 +7,8 @@ use crate::{filtration_system::MyResults, timer, Text};
 
 /// Breadth first search is our search algorithm
 /// https://en.wikipedia.org/wiki/Breadth-first_search
-pub fn bfs(input: &str, max_depth: Option<u32>) -> Option<Text> {
+pub fn bfs(input: &str) -> Option<Text> {
+    let config = get_config();
     let initial = Text {
         text: input.to_string(),
         path: vec![],
@@ -18,12 +20,12 @@ pub fn bfs(input: &str, max_depth: Option<u32>) -> Option<Text> {
     let mut curr_depth: u32 = 1; // as we have input string, so we start from 1
 
     let (result_send, result_recv) = bounded(1);
-    let timer = timer::start(5); // even 1 sec is enough ;D
+    let timer = timer::start(config.timeout);
 
     // loop through all of the strings in the vec
-    while !current_strings.is_empty() && max_depth.map_or(true, |x| curr_depth <= x) {
+    while !current_strings.is_empty() {
         trace!("Number of potential decodings: {}", current_strings.len());
-        trace!("Current depth is {:?}; [ {:?} max ]", curr_depth, max_depth);
+        trace!("Current depth is {:?}", curr_depth);
 
         let mut new_strings: Vec<Text> = vec![];
 
@@ -79,7 +81,7 @@ pub fn bfs(input: &str, max_depth: Option<u32>) -> Option<Text> {
                 }
             },
             recv(timer) -> _ => {
-                error!("TIMEOUT!!!");
+                error!("Ares failed to decrypt the text you have provided within {} seconds, it is unlikely to be decoded.", config.timeout);
                 return None;
             },
             default => continue,
@@ -101,7 +103,7 @@ mod tests {
         // let result = bfs("Q0FOQVJZOiBoZWxsbw==");
         // assert!(result.is_some());
         // assert!(result.unwrap() == "CANARY: hello");
-        let result = bfs("b2xsZWg=", None);
+        let result = bfs("b2xsZWg=");
         assert!(result.is_some());
         assert!(result.unwrap().text == "hello");
     }
@@ -117,20 +119,9 @@ mod tests {
     fn non_deterministic_like_behaviour_regression_test() {
         // text was too long, so we put \ to escape the \n
         // and put the rest of string on next line.
-        let result = bfs(
-            "UFRCRVRWVkNiRlZMTVVkYVVFWjZVbFZPU0\
-        dGMU1WVlpZV2d4VkRVNWJWWnJjRzFVUlhCc1pYSlNWbHBPY0VaV1ZXeHJWRWd4TUZWdlZsWlg=",
-            None,
-        );
+        let result = bfs("UFRCRVRWVkNiRlZMTVVkYVVFWjZVbFZPU0\
+        dGMU1WVlpZV2d4VkRVNWJWWnJjRzFVUlhCc1pYSlNWbHBPY0VaV1ZXeHJWRWd4TUZWdlZsWlg=");
         assert!(result.is_some());
         assert_eq!(result.unwrap().text, "https://www.google.com");
-    }
-
-    #[test]
-    fn max_depth_test() {
-        // text is encoded with base64 5 times
-        let result = bfs("VjFaV2ExWXlUWGxUYTJoUVVrUkJPUT09", Some(4));
-        // It goes only upto depth 4, so it can't find the plaintext
-        assert!(result.is_none());
     }
 }

--- a/src/searchers/mod.rs
+++ b/src/searchers/mod.rs
@@ -28,9 +28,9 @@ mod bfs;
 /// We can return an Option? An Enum? And then match on that
 /// So if we return CrackSuccess we return
 /// Else if we return an array, we add it to the children and go again.
-pub fn search_for_plaintext(input: &str, max_depth: Option<u32>) -> Option<Text> {
+pub fn search_for_plaintext(input: &str) -> Option<Text> {
     // Change this to select which search algorithm we want to use.
-    bfs::bfs(input, max_depth)
+    bfs::bfs(input)
 }
 
 /// Performs the decodings by getting all of the decoders


### PR DESCRIPTION
This PR does a few times:
1. Remove max_depth from the equation
2. Cleans up the timeout function warning text etc
3. Uses config values instead of hard-coding it in
4. Keeps current depth counter so we can report it back to the user later on <3