### PR TITLE
feat: remove unused deps and set codegen unit to 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,12 +348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,16 +569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "plotters"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +644,6 @@ dependencies = [
  "lemmeknow",
  "log",
  "once_cell",
- "petgraph",
  "rayon",
  "text_io",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ log = "0.4"
 env_logger = "0.9.3"
 base64 = "0.13.1"
 rayon = "1.6.0"
-petgraph = "0.6.0"
 lemmeknow = "0.7.0"
 include_dir = "0.7.3"
 once_cell = "1.16.0"
@@ -36,7 +35,7 @@ crossbeam = "0.8"
 criterion = "0.4.0"
 
 [profile.release]
-lto = "fat"
+lto = "thin"
 panic = "abort"
 strip = "symbols"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,10 @@ crossbeam = "0.8"
 criterion = "0.4.0"
 
 [profile.release]
-lto = "thin"
+lto = "fat"
 panic = "abort"
 strip = "symbols"
+codegen-units = 1
 
 [[bench]]
 name = "benchmark_crackers"


### PR DESCRIPTION
ThinLTO is sometimes better than FullLTO. [rust-blog](https://blog.rust-lang.org/inside-rust/2020/06/29/lto-improvements.html)

EDIT: For us, full lto with 1 codegen unit performs best as of now.