### PR TITLE
return CrackResult instead of decoder names in path

### DIFF
--- a/src/decoders/crack_results.rs
+++ b/src/decoders/crack_results.rs
@@ -7,6 +7,7 @@ use super::interface::Decoder;
 
 /// Every cracker returns this object which
 /// Either indicates success or failure among other things.
+#[derive(Debug, Clone)]
 pub struct CrackResult {
     /// If our checkers return success, we change this bool to True
     pub success: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ mod storage;
 mod timer;
 
 use crate::config::Config;
+
+use self::decoders::crack_results::CrackResult;
 /// The main function to call which performs the cracking.
 /// ```rust
 /// use ares::perform_cracking;
@@ -58,7 +60,7 @@ pub struct Text {
     /// text we got
     pub text: String,
     /// decoder used so far to get this text
-    pub path: Vec<&'static str>,
+    pub path: Vec<CrackResult>,
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,20 @@ fn main() {
     let (text, config) = parse_cli_args();
     let result = perform_cracking(&text, config);
     match result {
+        // TODO: As result have array of CrackResult used,
+        // we can print in better way with more info
         Some(result) => {
             println!("SUCCESSFUL 😁");
             println!("PLAINTEXT: {:?}", result.text);
-            println!("DECODERS USED: {}", result.path.join(" → "))
+            println!(
+                "DECODERS USED: {}",
+                result
+                    .path
+                    .iter()
+                    .map(|c| c.decoder)
+                    .collect::<Vec<_>>()
+                    .join(" → ")
+            )
         }
         None => println!("FAILED 😭"),
     }

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -37,9 +37,10 @@ pub fn bfs(input: &str) -> Option<Text> {
                 // so just stop processing further.
                 MyResults::Break(res) => {
                     let mut decoders_used = current_string.path;
-                    decoders_used.push(res.decoder);
+                    let text = res.unencrypted_text.clone().unwrap_or_default();
+                    decoders_used.push(res);
                     let result_text = Text {
-                        text: res.unencrypted_text.unwrap_or_default(),
+                        text ,
                         path: decoders_used,
                     };
 
@@ -54,9 +55,10 @@ pub fn bfs(input: &str) -> Option<Text> {
                             .into_iter()
                             .map(|r| {
                                 let mut decoders_used = current_string.path.clone();
-                                decoders_used.push(r.decoder);
+                                let text = r.unencrypted_text.clone().unwrap_or_default();
+                                decoders_used.push(r);
                                 Text {
-                                    text: r.unencrypted_text.unwrap_or_default(),
+                                    text,
                                     path: decoders_used,
                                 }
                             })

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -40,7 +40,7 @@ pub fn bfs(input: &str) -> Option<Text> {
                     let text = res.unencrypted_text.clone().unwrap_or_default();
                     decoders_used.push(res);
                     let result_text = Text {
-                        text ,
+                        text,
                         path: decoders_used,
                     };
 


### PR DESCRIPTION
This will be helpful when we need other information from decoders, like key used, etc.