### PR TITLE
Enable multi-level decodings to actually work (Caesar) in multi-level paths

### DIFF
--- a/src/decoders/atbash_decoder.rs
+++ b/src/decoders/atbash_decoder.rs
@@ -45,7 +45,7 @@ impl Crack for Decoder<AtbashDecoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -86,7 +86,7 @@ mod tests {
     fn test_atbash() {
         let decoder = Decoder::<AtbashDecoder>::new();
         let result = decoder.crack("svool dliow", &get_athena_checker());
-        assert_eq!(result.unencrypted_text.unwrap(), "hello world");
+        assert_eq!(result.unencrypted_text.unwrap()[0], "hello world");
     }
 
     #[test]
@@ -97,7 +97,7 @@ mod tests {
             &get_athena_checker(),
         );
         assert_eq!(
-            result.unencrypted_text.unwrap(),
+            result.unencrypted_text.unwrap()[0],
             "Atbash Should Keep Capitalization like THIS"
         );
     }
@@ -110,7 +110,7 @@ mod tests {
             &get_athena_checker(),
         );
         assert_eq!(
-            result.unencrypted_text.unwrap(),
+            result.unencrypted_text.unwrap()[0],
             "Atbash should leave characters like these: ',.39=_#%^ intact after decoding!"
         );
     }

--- a/src/decoders/base32_decoder.rs
+++ b/src/decoders/base32_decoder.rs
@@ -29,7 +29,7 @@ use log::{debug, info, trace};
 ///
 /// let result = decode_base32.crack("NBSWY3DPEB3W64TMMQ======", &checker).unencrypted_text;
 /// assert!(result.is_some());
-/// assert_eq!(result.unwrap(), "hello world");
+/// assert_eq!(result.unwrap()[0], "hello world");
 /// ```
 pub struct Base32Decoder;
 

--- a/src/decoders/base32_decoder.rs
+++ b/src/decoders/base32_decoder.rs
@@ -72,7 +72,7 @@ impl Crack for Decoder<Base32Decoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -116,7 +116,7 @@ mod tests {
         let decoded_str = &result
             .unencrypted_text
             .expect("No unencrypted text for base32");
-        assert_eq!(decoded_str, "hello world");
+        assert_eq!(decoded_str[0], "hello world");
     }
 
     #[test]

--- a/src/decoders/base58_bitcoin_decoder.rs
+++ b/src/decoders/base58_bitcoin_decoder.rs
@@ -71,7 +71,7 @@ impl Crack for Decoder<Base58BitcoinDecoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -118,7 +118,7 @@ mod tests {
         let decoded_str = &result
             .unencrypted_text
             .expect("No unencrypted text for base58_bitcoin");
-        assert_eq!(decoded_str, "hello world");
+        assert_eq!(decoded_str[0], "hello world");
     }
 
     #[test]

--- a/src/decoders/base58_bitcoin_decoder.rs
+++ b/src/decoders/base58_bitcoin_decoder.rs
@@ -28,7 +28,7 @@ use log::{debug, info, trace};
 ///
 /// let result = decode_base58_bitcoin.crack("StV1DL6CwTryKyV", &checker).unencrypted_text;
 /// assert!(result.is_some());
-/// assert_eq!(result.unwrap(), "hello world");
+/// assert_eq!(result.unwrap()[0], "hello world");
 /// ```
 pub struct Base58BitcoinDecoder;
 

--- a/src/decoders/base58_flickr_decoder.rs
+++ b/src/decoders/base58_flickr_decoder.rs
@@ -71,7 +71,7 @@ impl Crack for Decoder<Base58FlickrDecoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -118,7 +118,7 @@ mod tests {
         let decoded_str = &result
             .unencrypted_text
             .expect("No unencrypted text for base58_flickr");
-        assert_eq!(decoded_str, "hello world");
+        assert_eq!(decoded_str[0], "hello world");
     }
 
     #[test]

--- a/src/decoders/base58_flickr_decoder.rs
+++ b/src/decoders/base58_flickr_decoder.rs
@@ -28,7 +28,7 @@ use log::{debug, info, trace};
 ///
 /// let result = decode_base58_flickr.crack("rTu1dk6cWsRYjYu", &checker).unencrypted_text;
 /// assert!(result.is_some());
-/// assert_eq!(result.unwrap(), "hello world");
+/// assert_eq!(result.unwrap()[0], "hello world");
 /// ```
 pub struct Base58FlickrDecoder;
 

--- a/src/decoders/base58_monero_decoder.rs
+++ b/src/decoders/base58_monero_decoder.rs
@@ -28,7 +28,7 @@ use log::{debug, info, trace};
 ///
 /// let result = decode_base58_monero.crack("StV1DL6CwTryKyV", &checker).unencrypted_text;
 /// assert!(result.is_some());
-/// assert_eq!(result.unwrap(), "hello world");
+/// assert_eq!(result.unwrap()[0], "hello world");
 /// ```
 pub struct Base58MoneroDecoder;
 

--- a/src/decoders/base58_monero_decoder.rs
+++ b/src/decoders/base58_monero_decoder.rs
@@ -71,7 +71,7 @@ impl Crack for Decoder<Base58MoneroDecoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -118,7 +118,7 @@ mod tests {
         let decoded_str = &result
             .unencrypted_text
             .expect("No unencrypted text for base58_monero");
-        assert_eq!(decoded_str, "hello world");
+        assert_eq!(decoded_str[0], "hello world");
     }
 
     #[test]

--- a/src/decoders/base58_ripple_decoder.rs
+++ b/src/decoders/base58_ripple_decoder.rs
@@ -71,7 +71,7 @@ impl Crack for Decoder<Base58RippleDecoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -118,7 +118,7 @@ mod tests {
         let decoded_str = &result
             .unencrypted_text
             .expect("No unencrypted text for base58_ripple");
-        assert_eq!(decoded_str, "hello world");
+        assert_eq!(decoded_str[0], "hello world");
     }
 
     #[test]

--- a/src/decoders/base58_ripple_decoder.rs
+++ b/src/decoders/base58_ripple_decoder.rs
@@ -28,7 +28,7 @@ use log::{debug, info, trace};
 ///
 /// let result = decode_base58_ripple.crack("StVrDLaUATiyKyV", &checker).unencrypted_text;
 /// assert!(result.is_some());
-/// assert_eq!(result.unwrap(), "hello world");
+/// assert_eq!(result.unwrap()[0], "hello world");
 /// ```
 pub struct Base58RippleDecoder;
 

--- a/src/decoders/base64_decoder.rs
+++ b/src/decoders/base64_decoder.rs
@@ -28,7 +28,7 @@ use log::{debug, info, trace};
 ///
 /// let result = decode_base64.crack("aGVsbG8gd29ybGQ=", &checker).unencrypted_text;
 /// assert!(result.is_some());
-/// assert_eq!(result.unwrap(), "hello world");
+/// assert_eq!(result.unwrap()[0], "hello world");
 /// ```
 pub struct Base64Decoder;
 

--- a/src/decoders/base64_decoder.rs
+++ b/src/decoders/base64_decoder.rs
@@ -71,7 +71,7 @@ impl Crack for Decoder<Base64Decoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -114,7 +114,7 @@ mod tests {
         let decoded_str = &result
             .unencrypted_text
             .expect("No unencrypted text for base64");
-        assert_eq!(decoded_str, "hello world");
+        assert_eq!(decoded_str[0], "hello world");
     }
 
     #[test]

--- a/src/decoders/base64_url_decoder.rs
+++ b/src/decoders/base64_url_decoder.rs
@@ -28,7 +28,7 @@ use log::{debug, info, trace};
 ///
 /// let result = decode_base64_url.crack("aHR0cHM6Ly93d3cuZ29vZ2xlLmNvbS8_ZXhhbXBsZT10ZXN0", &checker).unencrypted_text;
 /// assert!(result.is_some());
-/// assert_eq!(result.unwrap(), "https://www.google.com/?example=test");
+/// assert_eq!(result.unwrap()[0], "https://www.google.com/?example=test");
 /// ```
 pub struct Base64URLDecoder;
 

--- a/src/decoders/base64_url_decoder.rs
+++ b/src/decoders/base64_url_decoder.rs
@@ -71,7 +71,7 @@ impl Crack for Decoder<Base64URLDecoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -116,7 +116,7 @@ mod tests {
             &get_athena_checker(),
         );
         assert_eq!(
-            result.unencrypted_text.unwrap(),
+            result.unencrypted_text.unwrap()[0],
             "https://www.google.com/?example=test"
         );
     }
@@ -131,7 +131,7 @@ mod tests {
             &get_athena_checker(),
         );
         assert_eq!(
-            result.unencrypted_text.unwrap(),
+            result.unencrypted_text.unwrap()[0],
             "This is decodable by both Base64 and Base64 URL"
         );
     }

--- a/src/decoders/base65536_decoder.rs
+++ b/src/decoders/base65536_decoder.rs
@@ -28,7 +28,7 @@ use log::{debug, info, trace};
 ///
 /// let result = decode_base65536.crack("𒅓鹨𖡮𒀠啦ꍢ顡啫𓍱𓁡𠁴唬𓍪鱤啥𖥭𔐠𔕯ᔮ", &checker).unencrypted_text;
 /// assert!(result.is_some());
-/// assert_eq!(result.unwrap(), "Sphinx of black quartz, judge my vow.");
+/// assert_eq!(result.unwrap()[0], "Sphinx of black quartz, judge my vow.");
 /// ```
 pub struct Base65536Decoder;
 

--- a/src/decoders/base65536_decoder.rs
+++ b/src/decoders/base65536_decoder.rs
@@ -73,7 +73,7 @@ impl Crack for Decoder<Base65536Decoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -115,7 +115,7 @@ mod tests {
         let base65536_decoder = Decoder::<Base65536Decoder>::new();
         let result = base65536_decoder.crack("𒅓鹨𖡮𒀠啦ꍢ顡啫𓍱𓁡𠁴唬𓍪鱤啥𖥭𔐠𔕯ᔮ", &get_athena_checker());
         assert_eq!(
-            result.unencrypted_text.unwrap(),
+            result.unencrypted_text.unwrap()[0],
             "Sphinx of black quartz, judge my vow."
         );
     }

--- a/src/decoders/caesar_decoder.rs
+++ b/src/decoders/caesar_decoder.rs
@@ -54,8 +54,10 @@ impl Crack for Decoder<CaesarDecoder> {
     fn crack(&self, text: &str, checker: &CheckerTypes) -> CrackResult {
         trace!("Trying Caesar Cipher with text {:?}", text);
         let mut results = CrackResult::new(self, text.to_string());
+        let mut decoded_strings = Vec::new();
         for shift in 1..25 {
             let decoded_text = caesar(text, shift);
+            decoded_strings.push(decoded_text);
             if !check_string_success(&decoded_text, text) {
                 info!(
                     "Failed to decode caesar because check_string_success returned false on string {}. This means the string is 'funny' as it wasn't modified.",
@@ -67,11 +69,12 @@ impl Crack for Decoder<CaesarDecoder> {
             // If checkers return true, exit early with the correct result
             if checker_result.is_identified {
                 trace!("Found a match with caesar shift {}", shift);
-                results.unencrypted_text = Some(decoded_text);
+                results.unencrypted_text = Some(vec![decoded_text]);
                 results.update_checker(&checker_result);
                 return results;
             }
         }
+        results.unencrypted_text = Some(decoded_strings);
         results
     }
 }

--- a/src/decoders/caesar_decoder.rs
+++ b/src/decoders/caesar_decoder.rs
@@ -57,7 +57,7 @@ impl Crack for Decoder<CaesarDecoder> {
         let mut decoded_strings = Vec::new();
         for shift in 1..25 {
             let decoded_text = caesar(text, shift);
-            decoded_strings.push(decoded_text);
+            decoded_strings.push(decoded_text.clone());
             if !check_string_success(&decoded_text, text) {
                 info!(
                     "Failed to decode caesar because check_string_success returned false on string {}. This means the string is 'funny' as it wasn't modified.",
@@ -137,7 +137,7 @@ mod tests {
         let decoded_str = &result
             .unencrypted_text
             .expect("No unencrypted text for caesar");
-        assert_eq!(decoded_str, "attack");
+        assert_eq!(decoded_str[0], "attack");
     }
 
     #[test]
@@ -148,7 +148,7 @@ mod tests {
         let decoded_str = &result
             .unencrypted_text
             .expect("No unencrypted text for caesar");
-        assert_eq!(decoded_str, "hello this is long text");
+        assert_eq!(decoded_str[0], "hello this is long text");
     }
 
     #[test]
@@ -159,7 +159,7 @@ mod tests {
         let decoded_str = &result
             .unencrypted_text
             .expect("No unencrypted text for caesar");
-        assert_eq!(decoded_str, "Hello! this is long text?");
+        assert_eq!(decoded_str[0], "Hello! this is long text?");
     }
 
     #[test]

--- a/src/decoders/caesar_decoder.rs
+++ b/src/decoders/caesar_decoder.rs
@@ -28,7 +28,9 @@ use log::{info, trace};
 ///
 /// let result = decode_caesar.crack("uryyb guvf vf ybat grkg", &checker).unencrypted_text;
 /// assert!(result.is_some());
-/// assert_eq!(result.unwrap(), "hello this is long text");
+/// // If it succeeds, the 0th element is the plaintext else it'll contain 25 elements
+/// // of unsuccessfully decoded text
+/// assert_eq!(result.unwrap()[0], "hello this is long text");
 /// ```
 pub struct CaesarDecoder;
 

--- a/src/decoders/citrix_ctx1_decoder.rs
+++ b/src/decoders/citrix_ctx1_decoder.rs
@@ -65,7 +65,7 @@ impl Crack for Decoder<CitrixCTX1Decoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -129,7 +129,7 @@ mod tests {
             "MNGIKIANMEGBKIANMHGCOHECJADFPPFKINCIOBEEIFCA",
             &get_athena_checker(),
         );
-        assert_eq!(result.unencrypted_text.unwrap(), "hello world");
+        assert_eq!(result.unencrypted_text.unwrap()[0], "hello world");
     }
 
     #[test]
@@ -141,7 +141,7 @@ mod tests {
             &get_athena_checker(),
         );
         assert_eq!(
-            result.unencrypted_text.unwrap(),
+            result.unencrypted_text.unwrap()[0],
             "This is lowercase Citrix CTX1"
         );
     }
@@ -198,6 +198,6 @@ mod tests {
         // This tests if Citrix CTX1 can decode an emoji
         let citrix_ctx1_decoder = Decoder::<CitrixCTX1Decoder>::new();
         let result = citrix_ctx1_decoder.crack("😂", &get_athena_checker());
-        assert_eq!(result.unencrypted_text.unwrap(), "[*");
+        assert_eq!(result.unencrypted_text.unwrap()[0], "[*");
     }
 }

--- a/src/decoders/crack_results.rs
+++ b/src/decoders/crack_results.rs
@@ -15,7 +15,7 @@ pub struct CrackResult {
     pub encrypted_text: String,
     /// Unencrypted text is what it looks like after.
     /// if decoder failed, this will be None
-    pub unencrypted_text: Option<String>,
+    pub unencrypted_text: Option<Vec<String>>,
     /// Decoder is the function we used to decode the text
     pub decoder: &'static str,
     /// Checker which identified the text

--- a/src/decoders/morse_code.rs
+++ b/src/decoders/morse_code.rs
@@ -54,7 +54,7 @@ impl Crack for Decoder<MorseCodeDecoder> {
         }
 
         let checker_result = checker.check(&decoded_text);
-        results.unencrypted_text = Some(decoded_text);
+        results.unencrypted_text = Some(vec![decoded_text]);
 
         results.update_checker(&checker_result);
 
@@ -148,6 +148,6 @@ mod tests {
             ".---- ----. ..--- .-.-.- .---- -.... ---.. .-.-.- ----- .-.-.- .----",
             &get_athena_checker(),
         );
-        assert_eq!(result.unencrypted_text.unwrap(), "192.168.0.1");
+        assert_eq!(result.unencrypted_text.unwrap()[0], "192.168.0.1");
     }
 }

--- a/src/decoders/reverse_decoder.rs
+++ b/src/decoders/reverse_decoder.rs
@@ -59,7 +59,7 @@ impl Crack for Decoder<ReverseDecoder> {
         let rev_str: String = text.chars().rev().collect();
         let checker_res = checker.check(&rev_str);
 
-        result.unencrypted_text = Some(rev_str);
+        result.unencrypted_text = Some(vec![rev_str]);
         result.update_checker(&checker_res);
         result
     }
@@ -89,7 +89,7 @@ mod tests {
             .crack("stac", &get_athena_checker())
             .unencrypted_text
             .expect("No unencrypted string for reverse decoder");
-        assert_eq!(result, "cats");
+        assert_eq!(result[0], "cats");
     }
 
     #[test]

--- a/src/decoders/reverse_decoder.rs
+++ b/src/decoders/reverse_decoder.rs
@@ -23,7 +23,7 @@ use log::trace;
 ///
 /// let result = reversedecoder.crack("stac", &checker).unencrypted_text;
 /// assert!(result.is_some());
-/// assert_eq!(result.unwrap(), "cats");
+/// assert_eq!(result.unwrap()[0], "cats");
 /// ```
 pub struct ReverseDecoder;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ mod tests {
         let config = Config::default();
         let result = perform_cracking("b2xsZWg=", config);
         assert!(result.is_some());
-        assert!(result.unwrap().text == "hello");
+        assert!(result.unwrap().text[0] == "hello");
     }
     #[test]
     fn test_perform_cracking_returns_failure() {
@@ -97,6 +97,6 @@ mod tests {
         let config = Config::default();
         let result = perform_cracking("aGVsbG8gdGhlcmUgZ2VuZXJhbA==", config);
         assert!(result.is_some());
-        assert!(result.unwrap().text == "hello there general")
+        assert!(result.unwrap().text[0] == "hello there general")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub fn perform_cracking(text: &str, config: Config) -> Option<Text> {
 #[derive(Debug)]
 pub struct Text {
     /// text we got
-    pub text: String,
+    pub text: Vec<String>,
     /// decoder used so far to get this text
     pub path: Vec<CrackResult>,
 }

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,4 +1,4 @@
-use crate::config::get_config;
+use crate::{config::get_config, decoders::crack_results::CrackResult};
 use crossbeam::{channel::bounded, select};
 use log::{error, trace};
 use std::collections::HashSet;
@@ -30,10 +30,7 @@ pub fn bfs(input: &str) -> Option<Text> {
         let mut new_strings: Vec<Text> = vec![];
 
         current_strings.into_iter().try_for_each(|current_string| {
-            if&current_string.text.len() <= &0 {
-                return None
-            }
-            let res = super::perform_decoding(&current_string.text);
+            let res = super::perform_decoding(&current_string.text[0]);
 
             match res {
                 // if it's Break variant, we have cracked the text successfully
@@ -77,8 +74,20 @@ pub fn bfs(input: &str) -> Option<Text> {
                 }
             }
         });
-        // we should probabkly 
-        current_strings = new_strings;
+        let mut new_strings_to_be_added = Vec::new();
+        for textStruct in new_strings{
+            for decoded_text in textStruct.text{
+                new_strings_to_be_added.push(
+                    Text {
+                        text: vec![decoded_text],
+                        // quick hack
+                        path: textStruct.path.clone(),
+                    }
+                )
+            }
+            
+        }
+        current_strings = new_strings_to_be_added;
         curr_depth += 1;
 
         select! {

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -124,8 +124,6 @@ mod tests {
         let result = bfs("b2xsZWg=");
         assert!(result.is_some());
         let txt = result.unwrap().text;
-        error!("HELLO **********************");
-        error!("{:?}", txt);
         assert!(txt[0] == "hello");
     }
 

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -30,7 +30,10 @@ pub fn bfs(input: &str) -> Option<Text> {
         let mut new_strings: Vec<Text> = vec![];
 
         current_strings.into_iter().try_for_each(|current_string| {
-            let res = super::perform_decoding(&current_string.text[0]);
+            if&current_string.text.len() <= &0 {
+                return None
+            }
+            let res = super::perform_decoding(&current_string.text);
 
             match res {
                 // if it's Break variant, we have cracked the text successfully
@@ -109,12 +112,12 @@ mod tests {
     #[test]
     fn bfs_succeeds() {
         // this will work after english checker can identify "CANARY: hello"
-        // let result = bfs("Q0FOQVJZOiBoZWxsbw==");
-        // assert!(result.is_some());
-        // assert!(result.unwrap() == "CANARY: hello");
         let result = bfs("b2xsZWg=");
         assert!(result.is_some());
-        assert!(result.unwrap().text[0] == "hello");
+        let txt = result.unwrap().text;
+        error!("HELLO **********************");
+        error!("{:?}", txt);
+        assert!(txt[0] == "hello");
     }
 
     // Vector storing the strings to perform decoding in next iteraion

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -10,7 +10,7 @@ use crate::{filtration_system::MyResults, timer, Text};
 pub fn bfs(input: &str) -> Option<Text> {
     let config = get_config();
     let initial = Text {
-        text: input.to_string(),
+        text: vec![input.to_string()],
         path: vec![],
     };
     let mut seen_strings = HashSet::new();
@@ -30,7 +30,7 @@ pub fn bfs(input: &str) -> Option<Text> {
         let mut new_strings: Vec<Text> = vec![];
 
         current_strings.into_iter().try_for_each(|current_string| {
-            let res = super::perform_decoding(&current_string.text);
+            let res = super::perform_decoding(&current_string.text[0]);
 
             match res {
                 // if it's Break variant, we have cracked the text successfully
@@ -55,9 +55,15 @@ pub fn bfs(input: &str) -> Option<Text> {
                             .into_iter()
                             .map(|r| {
                                 let mut decoders_used = current_string.path.clone();
+                                // text is a vector of strings
                                 let text = r.unencrypted_text.clone().unwrap_or_default();
                                 decoders_used.push(r);
                                 Text {
+                                    // and this is a vector of strings
+                                    // TODO we should probably loop through all `text` and create Text structs for each one
+                                    // and append those structs
+                                    // I think we should keep text as a single string
+                                    // and just create more of them....
                                     text,
                                     path: decoders_used,
                                 }
@@ -68,6 +74,7 @@ pub fn bfs(input: &str) -> Option<Text> {
                 }
             }
         });
+        // we should probabkly 
         current_strings = new_strings;
         curr_depth += 1;
 

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,4 +1,4 @@
-use crate::{config::get_config, decoders::crack_results::CrackResult};
+use crate::{config::get_config};
 use crossbeam::{channel::bounded, select};
 use log::{error, trace};
 use std::collections::HashSet;
@@ -75,13 +75,13 @@ pub fn bfs(input: &str) -> Option<Text> {
             }
         });
         let mut new_strings_to_be_added = Vec::new();
-        for textStruct in new_strings{
-            for decoded_text in textStruct.text{
+        for text_struct in new_strings{
+            for decoded_text in text_struct.text{
                 new_strings_to_be_added.push(
                     Text {
                         text: vec![decoded_text],
                         // quick hack
-                        path: textStruct.path.clone(),
+                        path: text_struct.path.clone(),
                     }
                 )
             }
@@ -134,13 +134,12 @@ mod tests {
     // We want strings from all results, so to fix it,
     // we call .extend() to extend the vector.
     // Link to forum https://discord.com/channels/754001738184392704/1002135076034859068
+    // This also tests the bug whereby each iteration of caesar was not passed to the next decoder
+    // So in Ciphey only Rot1(X) was passed to base64, not Rot13(X)
     #[test]
     fn non_deterministic_like_behaviour_regression_test() {
-        // text was too long, so we put \ to escape the \n
-        // and put the rest of string on next line.
-        let result = bfs("UFRCRVRWVkNiRlZMTVVkYVVFWjZVbFZPU0\
-        dGMU1WVlpZV2d4VkRVNWJWWnJjRzFVUlhCc1pYSlNWbHBPY0VaV1ZXeHJWRWd4TUZWdlZsWlg=");
+        let result = bfs("MTkyLjE2OC4wLjE=");
         assert!(result.is_some());
-        assert_eq!(result.unwrap().text[0], "https://www.google.com");
+        assert_eq!(result.unwrap().text[0], "192.168.0.1");
     }
 }

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -114,7 +114,7 @@ mod tests {
         // assert!(result.unwrap() == "CANARY: hello");
         let result = bfs("b2xsZWg=");
         assert!(result.is_some());
-        assert!(result.unwrap().text == "hello");
+        assert!(result.unwrap().text[0] == "hello");
     }
 
     // Vector storing the strings to perform decoding in next iteraion
@@ -131,6 +131,6 @@ mod tests {
         let result = bfs("UFRCRVRWVkNiRlZMTVVkYVVFWjZVbFZPU0\
         dGMU1WVlpZV2d4VkRVNWJWWnJjRzFVUlhCc1pYSlNWbHBPY0VaV1ZXeHJWRWd4TUZWdlZsWlg=");
         assert!(result.is_some());
-        assert_eq!(result.unwrap().text, "https://www.google.com");
+        assert_eq!(result.unwrap().text[0], "https://www.google.com");
     }
 }

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -138,6 +138,7 @@ mod tests {
     // So in Ciphey only Rot1(X) was passed to base64, not Rot13(X)
     #[test]
     fn non_deterministic_like_behaviour_regression_test() {
+        // Caesar Cipher (Rot13) -> Base64
         let result = bfs("MTkyLjE2OC4wLjE=");
         assert!(result.is_some());
         assert_eq!(result.unwrap().text[0], "192.168.0.1");

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -1,4 +1,4 @@
-use crate::{config::get_config};
+use crate::config::get_config;
 use crossbeam::{channel::bounded, select};
 use log::{error, trace};
 use std::collections::HashSet;
@@ -75,17 +75,14 @@ pub fn bfs(input: &str) -> Option<Text> {
             }
         });
         let mut new_strings_to_be_added = Vec::new();
-        for text_struct in new_strings{
-            for decoded_text in text_struct.text{
-                new_strings_to_be_added.push(
-                    Text {
-                        text: vec![decoded_text],
-                        // quick hack
-                        path: text_struct.path.clone(),
-                    }
-                )
+        for text_struct in new_strings {
+            for decoded_text in text_struct.text {
+                new_strings_to_be_added.push(Text {
+                    text: vec![decoded_text],
+                    // quick hack
+                    path: text_struct.path.clone(),
+                })
             }
-            
         }
         current_strings = new_strings_to_be_added;
         curr_depth += 1;


### PR DESCRIPTION
Previously when we had something like:

```
Caesar -> Base64
```

Ares (and Ciphey) would take the first decoding of Caesar (Rot1(X)) and pass that to Base64. This PR makes it so all 25 shifts of Caesar (and other similar ciphers) are passed to the decoders.

# This works by....

Every `Text` struct contains a field:

```
text: Vec<String>,
```

Which contains every decoding (even if it's just 1 decoding).

After each iteration of BFS we loop over all of our vectors we have collected and flatten them from a `Vec<Vec<Text>>` to a `Vec<Text>` where `text: Vec<String>` has a single element (meaning we can index into the 0th element [0] and get the result).

```rust
        let mut new_strings_to_be_added = Vec::new();
        for textStruct in new_strings{
            for decoded_text in textStruct.text{
                new_strings_to_be_added.push(
                    Text {
                        text: vec![decoded_text],
                        // quick hack
                        path: textStruct.path.clone(),
                    }
                )
            }
```

This introduces some issues:

1. It is not efficient to have a O(n^2) loop after our big main loop
2. We are using .clone() here which is slow
3. It is not efficient to make a new vector with just 1 element
4. It does not support nice paths. If it was Caesar, it won't say "Caesar with shift of 13" for example

This is a hack to get us to support this feature.

In the future we might want to look at:

Editing this bit of code so it supports Vectors of Vectors:
https://github.com/bee-san/Ares/blob/1bcc994052db17e7db948055d012810353c76f4d/src/searchers/bfs.rs#LL32-L33C69

Or adding another loop below this code so it turns into a O(n^2) nested loop:
https://github.com/bee-san/Ares/blob/1bcc994052db17e7db948055d012810353c76f4d/src/searchers/bfs.rs#L26