### PR TITLE
Add how many times Ares has decoded to the output

### DIFF
--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -94,12 +94,13 @@ pub fn bfs(input: &str) -> Option<Text> {
                 // but this is a demo and i'll be lazy :P
                 let exit_result = exit_result.ok(); // convert Result to Some
                 if exit_result.is_some() {
+                    println!("Ares has decoded {times} times", times=curr_depth * (12+25));
                     trace!("Found exit result: {:?}", exit_result);
                     return exit_result;
                 }
             },
             recv(timer) -> _ => {
-                println!("Ares has decoded {times} times", times=curr_depth * (12+24));
+                println!("Ares has decoded {times} times", times=curr_depth * (12+25));
                 error!("Ares failed to decrypt the text you have provided within {} seconds, it is unlikely to be decoded.", config.timeout);
                 return None;
             },

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -99,6 +99,7 @@ pub fn bfs(input: &str) -> Option<Text> {
                 }
             },
             recv(timer) -> _ => {
+                println!("Ares has decoded {times} times", times=curr_depth * (12+24));
                 error!("Ares failed to decrypt the text you have provided within {} seconds, it is unlikely to be decoded.", config.timeout);
                 return None;
             },


### PR DESCRIPTION
This is calculated by:

```
println!("Ares has decoded {times} times", times=curr_depth * (12+25));
```

Which is:
* Curr_depth is the current level it is working at, each level runs every decoder once
* 12 decoders
* 25 iterations of Caesar Cipher

This is the easiest way I could think of to get this info, for things like viginere etc in the future it'd make sense to return an `Iterations` count in the `CrackResult` object :)