### PR TITLE
Fix bug where timer times out even though human checker is true

### DIFF
--- a/src/checkers/human_checker.rs
+++ b/src/checkers/human_checker.rs
@@ -25,7 +25,7 @@ pub fn human_checker(input: &CheckResult) -> bool {
     println!("{}", output_string);
     let reply: String = read!("{}\n");
     let result = reply.to_ascii_lowercase().starts_with('y');
-    if !result{
+    if !result {
         timer::resume();
         return false;
     }

--- a/src/checkers/human_checker.rs
+++ b/src/checkers/human_checker.rs
@@ -24,7 +24,10 @@ pub fn human_checker(input: &CheckResult) -> bool {
     // print output_string and ask user to input yes or no
     println!("{}", output_string);
     let reply: String = read!("{}\n");
-    timer::resume();
-
-    reply.to_ascii_lowercase().starts_with('y')
+    let result = reply.to_ascii_lowercase().starts_with('y');
+    if !result{
+        timer::resume();
+        return false;
+    }
+    return true;
 }

--- a/src/checkers/human_checker.rs
+++ b/src/checkers/human_checker.rs
@@ -29,5 +29,5 @@ pub fn human_checker(input: &CheckResult) -> bool {
         timer::resume();
         return false;
     }
-    return true;
+    true
 }


### PR DESCRIPTION
```
./ares -t 'Vm0wd2QyUXlWa1pPVldSWFYwZG9WRll3WkRSV1JsbDNXa2M1V0Zac2JETlhhMUpUVmpKS1IySkVUbGhoTVVwVVZtcEdZV1JIVmtkWGJGcE9ZV3RGZUZadE1UUlpWMDE0V2toV2FWSnRVbGhVVkVaTFZGWmFjMVp0UmxkTlZuQlhWRlpXVjJGSFZuRlJWR3M5'
I think the plaintext is a English.txt.
Possible plaintext: 'Hello' (y/N):
I think the plaintext is a English.txt.
Possible plaintext: 'Hello' (y/N):
y

Ares has decoded 444 times
[2022-11-29T15:52:09Z ERROR ares::searchers::bfs] Ares failed to decrypt the text you have provided within 5 seconds, it is unlikely to be decoded.
FAILED 😭
```

This way the timer is perma-paused if we return True here