### PR TITLE
Return early if the input is the plaintext

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,11 +69,14 @@ pub fn perform_cracking(text: &str, config: Config) -> Option<DecoderResult> {
     searchers::search_for_plaintext(text)
 }
 
+/// Checks if the given input is plaintext or not
+/// Used at the start of the program to not waste CPU cycles
 fn check_if_input_text_is_plaintext(text: &str) -> bool {
     let athena_checker = Checker::<Athena>::new();
     athena_checker.check(text).is_identified
 }
 
+/// A nice function to print when the input text is the plaintext
 fn return_early_because_input_text_is_plaintext() {
     println!("Your input text is the plaintext 🥳")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ mod storage;
 /// Timer for internal use
 mod timer;
 
+use checkers::{checker_type::{Checker, Check}, athena::Athena, CheckerTypes};
+use log::debug;
+
 use crate::config::Config;
 
 use self::decoders::crack_results::CrackResult;
@@ -45,6 +48,11 @@ use self::decoders::crack_results::CrackResult;
 /// assert!(true)
 /// ```
 pub fn perform_cracking(text: &str, config: Config) -> Option<Text> {
+    if check_if_input_text_is_plaintext(text){
+        debug!("The input text provided to the program {} is the plaintext. Returning early.", text);
+        return_early_becauseinput_text_is_plaintext();
+        return None
+    }
     // Build a new search tree
     // This starts us with a node with no parents
     // let search_tree = searchers::Tree::new(text.to_string());
@@ -52,6 +60,15 @@ pub fn perform_cracking(text: &str, config: Config) -> Option<Text> {
     // It will either return a failure or success.
     config::set_global_config(config);
     searchers::search_for_plaintext(text)
+}
+
+fn check_if_input_text_is_plaintext(text: &str) -> bool {
+    let athena_checker = Checker::<Athena>::new();
+    athena_checker.check(text).is_identified
+}
+
+fn return_early_becauseinput_text_is_plaintext(){
+    println!("Your input text is the plaintext 🥳")
 }
 
 /// Our custom text which also has path to get there
@@ -98,5 +115,13 @@ mod tests {
         let result = perform_cracking("aGVsbG8gdGhlcmUgZ2VuZXJhbA==", config);
         assert!(result.is_some());
         assert!(result.unwrap().text[0] == "hello there general")
+    }
+
+    #[test]
+    fn test_early_exit_if_input_is_plaintext() {
+        let config = Config::default();
+        let result = perform_cracking("192.168.0.1", config);
+        // We return None since the input is the plaintext
+        assert!(result.is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,10 @@ mod storage;
 /// Timer for internal use
 mod timer;
 
-use checkers::{checker_type::{Checker, Check}, athena::Athena};
+use checkers::{
+    athena::Athena,
+    checker_type::{Check, Checker},
+};
 use log::debug;
 
 use crate::config::Config;
@@ -48,10 +51,13 @@ use self::decoders::crack_results::CrackResult;
 /// assert!(true)
 /// ```
 pub fn perform_cracking(text: &str, config: Config) -> Option<DecoderResult> {
-    if check_if_input_text_is_plaintext(text){
-        debug!("The input text provided to the program {} is the plaintext. Returning early.", text);
+    if check_if_input_text_is_plaintext(text) {
+        debug!(
+            "The input text provided to the program {} is the plaintext. Returning early.",
+            text
+        );
         return_early_becauseinput_text_is_plaintext();
-        return None
+        return None;
     }
 
     // Build a new search tree
@@ -68,7 +74,7 @@ fn check_if_input_text_is_plaintext(text: &str) -> bool {
     athena_checker.check(text).is_identified
 }
 
-fn return_early_becauseinput_text_is_plaintext(){
+fn return_early_becauseinput_text_is_plaintext() {
     println!("Your input text is the plaintext 🥳")
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ mod storage;
 /// Timer for internal use
 mod timer;
 
-use checkers::{checker_type::{Checker, Check}, athena::Athena, CheckerTypes};
+use checkers::{checker_type::{Checker, Check}, athena::Athena};
 use log::debug;
 
 use crate::config::Config;
@@ -47,13 +47,13 @@ use self::decoders::crack_results::CrackResult;
 /// perform_cracking("VGhlIG1haW4gZnVuY3Rpb24gdG8gY2FsbCB3aGljaCBwZXJmb3JtcyB0aGUgY3JhY2tpbmcu", Config::default());
 /// assert!(true)
 /// ```
-pub fn perform_cracking(text: &str, config: Config) -> Option<Text> {
+pub fn perform_cracking(text: &str, config: Config) -> Option<DecoderResult> {
     if check_if_input_text_is_plaintext(text){
         debug!("The input text provided to the program {} is the plaintext. Returning early.", text);
         return_early_becauseinput_text_is_plaintext();
         return None
     }
-pub fn perform_cracking(text: &str, config: Config) -> Option<DecoderResult> {
+
     // Build a new search tree
     // This starts us with a node with no parents
     // let search_tree = searchers::Tree::new(text.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub fn perform_cracking(text: &str, config: Config) -> Option<DecoderResult> {
             "The input text provided to the program {} is the plaintext. Returning early.",
             text
         );
-        return_early_becauseinput_text_is_plaintext();
+        return_early_because_input_text_is_plaintext();
         return None;
     }
 
@@ -74,7 +74,7 @@ fn check_if_input_text_is_plaintext(text: &str) -> bool {
     athena_checker.check(text).is_identified
 }
 
-fn return_early_becauseinput_text_is_plaintext() {
+fn return_early_because_input_text_is_plaintext() {
     println!("Your input text is the plaintext 🥳")
 }
 


### PR DESCRIPTION
Currently Ares doesn't check the initial input with its checkers. This causes weird printing like this:
```
cargo run -- -t '192.168.0.1'
I think the plaintext is a Internet Protocol (IP) Address Version 4.
Possible plaintext: '192.168.0.1' (y/N):
y
Ares has decoded 111 times
SUCCESSFUL 😁
PLAINTEXT: ["192.168.0.1"]
DECODERS USED: Reverse → Reverse
```

With this PR Ares returns early if the input passes any of our checkers.

This is enabled in `lib.rs` which is used both by the API and the CLI.