### PR TITLE
Change positioning of timer::pause in human checker fixing bug where API would panic no matter what

### DIFF
--- a/src/checkers/human_checker.rs
+++ b/src/checkers/human_checker.rs
@@ -9,6 +9,7 @@ use text_io::read;
 /// TODO: Add a way to specify a list of checkers to use in the library. This checker is not library friendly!
 // compile this if we are not running tests
 pub fn human_checker(input: &CheckResult) -> bool {
+    timer::pause();
     // wait instead of get so it waits for config being set
     let config = get_config();
     // We still call human checker, just if config is false we return True
@@ -16,7 +17,6 @@ pub fn human_checker(input: &CheckResult) -> bool {
         return true;
     }
 
-    timer::pause();
     let output_string = format!(
         "I think the plaintext is a {}.\nPossible plaintext: '{}' (y/N): ",
         input.description, input.text


### PR DESCRIPTION
Previously our logic looked like this:
* Check to see if API is on, if it is return True
* If it's not, pause human checker
* Perform human checker

This led to a glitch where the program would return with something, but the timer would still run and return a panic.

As we always return True for the HumanChecker if our API is on, we do not need to worry about whether or not the data passes any human checks and can just pause it.