### PR TITLE
Automatically publish to Cargo on new release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,19 @@
+name: Publish to Cargo
+
+# When we publish a new release
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker: 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: true
+      - uses: katyo/publish-crates@v1
+        with:
+            registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This adds an action that when we create a new release it publishes the crate to Cargo. This is so we can have a nice workflow like:
* Click Release
* Dependabot on the Discord bot opens a PR to update Ares
* Merge it automatically (we can tell dependabot to auto-merge Ares PRs)
* Discord-bot github has a similar action to publish to Docker
* Kubernetes updates to latest docker image

Discord bot will therefore be around a day or two out of date at most :)