### PR TITLE
Add timeout to CLI argument and improve API documentation

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,11 +3,11 @@ use crate::config::Config;
 /// as do all doc strings on fields
 use clap::Parser;
 use lemmeknow::Identifier;
-use log::{debug, trace};
+use log::trace;
 
 /// The struct for Clap CLI arguments
 #[derive(Parser)]
-#[command(author = "Bee <bee@skerritt.blog>", version = "1.0", about, long_about = None)]
+#[command(author = "Bee <bee@skerritt.blog>", about, long_about = None)]
 pub struct Opts {
     /// Some input. Because this isn't an Option<T> it's required to be used
     #[arg(short, long)]
@@ -17,13 +17,16 @@ pub struct Opts {
     #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
 
-    /// Turn off human checker
+    /// Turn off human checker, perfect for APIs where you don't want input from humans
     #[arg(short, long)]
     disable_human_checker: bool,
 
-    /// Maximum number of decodings to perform on a string
-    #[arg(short, long, default_value = "10000")]
-    max_depth: u32,
+    /// Set timeout, if it is not decrypted after this time, it will return an error.
+    /// Default is 5 seconds.
+    // If we want to call it `timeout`, the short argument contends with the one for Text `ares -t`.
+    // I propose we just call it `cracking_timeout`.
+    #[arg(short, long)]
+    cracking_timeout: u32,
 }
 
 /// Parse CLI Arguments turns a Clap Opts struct, seen above
@@ -42,8 +45,6 @@ pub fn parse_cli_args() -> (String, Config) {
     );
     trace!("Program was called with CLI 😉");
     trace!("Parsed the arguments");
-    debug!("{:?}", opts.text);
-    debug!("{:?}", opts.verbose);
 
     cli_args_into_config_struct(opts)
 }
@@ -59,7 +60,7 @@ fn cli_args_into_config_struct(opts: Opts) -> (String, Config) {
             human_checker_on: !opts.disable_human_checker,
             offline_mode: true,
             // TODO make this into a CLI arg
-            timeout: 5,
+            timeout: opts.cracking_timeout,
         },
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,35 @@ use self::decoders::crack_results::CrackResult;
 /// ```rust
 /// use ares::perform_cracking;
 /// use ares::config::Config;
-///
-/// perform_cracking("VGhlIG1haW4gZnVuY3Rpb24gdG8gY2FsbCB3aGljaCBwZXJmb3JtcyB0aGUgY3JhY2tpbmcu", Config::default());
-/// assert!(true)
+/// let mut config = Config::default();
+/// // You can set the config to your liking using the Config struct
+/// // Just edit the data like below if you want:
+/// config.timeout = 5;
+/// config.human_checker_on = false;
+/// config.verbose = 0;
+/// let result = perform_cracking("VGhlIG1haW4gZnVuY3Rpb24gdG8gY2FsbCB3aGljaCBwZXJmb3JtcyB0aGUgY3JhY2tpbmcu", config);
+/// assert!(true);
+/// // The result is an Option<DecoderResult> so we need to unwrap it
+/// // The DecoderResult contains the text and the path
+/// // The path is a vector of CrackResults which contains the decoder used and the keys used
+/// // The text is a vector of strings because some decoders return more than 1 text (Caesar)
+/// // Becuase the program has returned True, the first result is the plaintext (and it will only have 1 result).
+/// // This is some tech debt we need to clean up https://github.com/bee-san/Ares/issues/130
+/// assert!(result.unwrap().text[0] == "The main function to call which performs the cracking.");
+/// ```
+/// The human checker defaults to off in the config, but it returns the first thing it finds currently.
+/// We have an issue for that here https://github.com/bee-san/Ares/issues/129
+/// ```rust
+/// use ares::perform_cracking;
+/// use ares::config::Config;
+/// let mut config = Config::default();
+/// // You can set the config to your liking using the Config struct
+/// // Just edit the data like below if you want:
+/// config.timeout = 1;
+/// let result = perform_cracking("thisisatestthatitwillneverget111", config);
+/// assert!(true);
+/// // If the program times out, or it cannot decode the text it will return None.
+/// assert!(result.is_none());
 /// ```
 pub fn perform_cracking(text: &str, config: Config) -> Option<DecoderResult> {
     if check_if_input_text_is_plaintext(text) {


### PR DESCRIPTION
```
cargo run -- -t 'YGBgaGVsbG8gdGhlcmVgYGbbA=' -c 10
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/ares -t YGBgaGVsbG8gdGhlcmVgYGbbA= -c 10`
5 seconds have passed. 5 remaining
FAILED 😭
```

5 remaining! How great!

I updated the help text too:

```
Automated decoding tool, Ciphey but in Rust

Usage: ares [OPTIONS] --text <TEXT> --cracking-timeout <CRACKING_TIMEOUT>

Options:
  -t, --text <TEXT>
          Some input. Because this isn't an Option<T> it's required to be used
  -v, --verbose...
          A level of verbosity, and can be used multiple times
  -d, --disable-human-checker
          Turn off human checker, perfect for APIs where you don't want input from humans
  -c, --cracking-timeout <CRACKING_TIMEOUT>
          Set timeout, if it is not decrypted after this time, it will return an error. Default is 5 seconds
  -h, --help
          Print help information
```