### PR TITLE
Ensure BFS does not search on texts < 2 chars long

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,8 @@ use self::decoders::crack_results::CrackResult;
 /// let mut config = Config::default();
 /// // You can set the config to your liking using the Config struct
 /// // Just edit the data like below if you want:
-/// config.timeout = 1;
-/// let result = perform_cracking("thisisatestthatitwillneverget111", config);
+/// config.timeout = 0;
+/// let result = perform_cracking("VGhlIG1haW4gZnVuY3Rpb24gdG8gY2FsbCB3aGljaCBwZXJmb3JtcyB0aGUgY3JhY2tpbmcu", config);
 /// assert!(true);
 /// // If the program times out, or it cannot decode the text it will return None.
 /// assert!(result.is_none());

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -78,7 +78,7 @@ pub fn bfs(input: &str) -> Option<DecoderResult> {
         let mut new_strings_to_be_added = Vec::new();
         for text_struct in new_strings {
             for decoded_text in text_struct.text {
-                if check_if_string_can_be_decoded(&decoded_text) {
+                if check_if_string_cant_be_decoded(&decoded_text) {
                     continue;
                 }
                 new_strings_to_be_added.push(DecoderResult {
@@ -118,8 +118,8 @@ pub fn bfs(input: &str) -> Option<DecoderResult> {
 }
 
 /// If this returns False it will not attempt to decode that string
-fn check_if_string_can_be_decoded(text: &str) -> bool {
-    text.len() < 2
+fn check_if_string_cant_be_decoded(text: &str) -> bool {
+    text.len() <= 2
 }
 
 #[cfg(test)]
@@ -150,5 +150,20 @@ mod tests {
         let result = bfs("MTkyLjE2OC4wLjE=");
         assert!(result.is_some());
         assert_eq!(result.unwrap().text[0], "192.168.0.1");
+    }
+
+    #[test]
+    fn string_size_checker_returns_bad_if_string_cant_be_decoded() {
+        // Should return true because it cant decode it
+        let text = "12";
+        assert_eq!(check_if_string_cant_be_decoded(&text), true);
+    }
+
+
+    #[test]
+    fn string_size_checker_returns_ok_if_string_can_be_decoded() {
+        // Should return true because it cant decode it
+        let text = "123";
+        assert_eq!(check_if_string_cant_be_decoded(&text), false);
     }
 }

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -159,7 +159,6 @@ mod tests {
         assert_eq!(check_if_string_cant_be_decoded(&text), true);
     }
 
-
     #[test]
     fn string_size_checker_returns_ok_if_string_can_be_decoded() {
         // Should return true because it cant decode it

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -78,6 +78,9 @@ pub fn bfs(input: &str) -> Option<DecoderResult> {
         let mut new_strings_to_be_added = Vec::new();
         for text_struct in new_strings {
             for decoded_text in text_struct.text {
+                if !check_if_string_can_be_decoded(&decoded_text) {
+                    continue;
+                }
                 new_strings_to_be_added.push(DecoderResult {
                     text: vec![decoded_text],
                     // quick hack
@@ -112,6 +115,11 @@ pub fn bfs(input: &str) -> Option<DecoderResult> {
     }
 
     None
+}
+
+/// If this returns False it will not attempt to decode that string
+fn check_if_string_can_be_decoded(text: &str) -> bool {
+    text.len() > 2
 }
 
 #[cfg(test)]

--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -78,7 +78,7 @@ pub fn bfs(input: &str) -> Option<DecoderResult> {
         let mut new_strings_to_be_added = Vec::new();
         for text_struct in new_strings {
             for decoded_text in text_struct.text {
-                if !check_if_string_can_be_decoded(&decoded_text) {
+                if check_if_string_can_be_decoded(&decoded_text) {
                     continue;
                 }
                 new_strings_to_be_added.push(DecoderResult {
@@ -119,7 +119,7 @@ pub fn bfs(input: &str) -> Option<DecoderResult> {
 
 /// If this returns False it will not attempt to decode that string
 fn check_if_string_can_be_decoded(text: &str) -> bool {
-    text.len() > 2
+    text.len() < 2
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Previously Ares was trying to decode text with 1 or 2 chars:

```
[2022-12-12T13:01:16Z TRACE ares::decoders::binary_decoder] Trying binary with text "J"
```

I do not believe 1 or 2 chars are meaningful and they will not pass any of our checkers, so it is a bit pointless currently to try to decode them.

This PR adds a function which checks their size and if they are not large enough (more than 3 chars) they are not included in the strings to be decoded.

This should also provide a mild speed boost.

# Docs

I also updated one of the docs to include a real string and set the config timeout to 0 seconds to both:
* Test setting config timeout in API works (via doc-tests)
* You can make Ares not do anything by setting it to 0 (not useful, it's just nice to prove it works!)
