### PR TITLE
Add regex checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "data-encoding",
  "env_logger",
  "include_dir",
+ "lazy_static",
  "lemmeknow",
  "log",
  "num",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9656bf98b413727b974a451039bc00ce546c3de9440cb4a7b65222b71e17cc"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3c3042a5f73640f091fda4175798f2b51c2107deeab18e3017873a4772dd36"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.42"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -806,12 +829,14 @@ dependencies = [
  "data-encoding",
  "env_logger",
  "include_dir",
+ "lazy-regex",
  "lazy_static",
  "lemmeknow",
  "log",
  "num",
  "once_cell",
  "rayon",
+ "regex",
  "text_io",
 ]
 
@@ -857,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1007,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ num = "0.4"
 crossbeam = "0.8"
 base65536 = "1.0.1"
 ansi_term = "0.12.1"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ crossbeam = "0.8"
 base65536 = "1.0.1"
 ansi_term = "0.12.1"
 lazy_static = "1.4.0"
+lazy-regex = "2.3.1"
+regex = "1.7.0"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/checkers/athena.rs
+++ b/src/checkers/athena.rs
@@ -6,7 +6,8 @@ use super::{
     checker_type::{Check, Checker},
     english::EnglishChecker,
     human_checker,
-    lemmeknow_checker::LemmeKnow, regex_checker::RegexChecker,
+    lemmeknow_checker::LemmeKnow,
+    regex_checker::RegexChecker,
 };
 
 /// Athena checker runs all other checkers
@@ -30,7 +31,7 @@ impl Check for Checker<Athena> {
     fn check(&self, text: &str) -> CheckResult {
         let config = get_config();
         // Only run regex if its in the config
-        if config.regex.is_some(){
+        if config.regex.is_some() {
             trace!("running regex");
             let regex_checker = Checker::<RegexChecker>::new();
             let regex_result = regex_checker.check(text);
@@ -39,7 +40,7 @@ impl Check for Checker<Athena> {
                 check_res.is_identified = human_checker::human_checker(&regex_result);
                 return check_res;
             }
-        } else{
+        } else {
             // In Ciphey if the user uses the regex checker all the other checkers turn off
             // This is because they are looking for one specific bit of information so will not want the other checkers
             // TODO: wrap all checkers in oncecell so we only create them once!

--- a/src/checkers/athena.rs
+++ b/src/checkers/athena.rs
@@ -1,11 +1,11 @@
-use crate::checkers::checker_result::CheckResult;
+use crate::{checkers::checker_result::CheckResult, config::get_config};
 use lemmeknow::Identifier;
 
 use super::{
     checker_type::{Check, Checker},
     english::EnglishChecker,
     human_checker,
-    lemmeknow_checker::LemmeKnow,
+    lemmeknow_checker::LemmeKnow, regex_checker::RegexChecker,
 };
 
 /// Athena checker runs all other checkers
@@ -27,21 +27,35 @@ impl Check for Checker<Athena> {
     }
 
     fn check(&self, text: &str) -> CheckResult {
-        // TODO: wrap all checkers in oncecell so we only create them once!
-        let lemmeknow = Checker::<LemmeKnow>::new();
-        let lemmeknow_result = lemmeknow.check(text);
-        if lemmeknow_result.is_identified {
-            let mut check_res = CheckResult::new(&lemmeknow);
-            check_res.is_identified = human_checker::human_checker(&lemmeknow_result);
-            return check_res;
-        }
+        let config = get_config();
+        // Only run regex if its in the config
+        if config.regex.is_some(){
+            let regex_checker = Checker::<RegexChecker>::new();
+            let regex_result = regex_checker.check(text);
+            if regex_result.is_identified {
+                let mut check_res = CheckResult::new(&regex_checker);
+                check_res.is_identified = human_checker::human_checker(&regex_result);
+                return check_res;
+            }
+        } else{
+            // In Ciphey if the user uses the regex checker all the other checkers turn off
+            // This is because they are looking for one specific bit of information so will not want the other checkers
+            // TODO: wrap all checkers in oncecell so we only create them once!
+            let lemmeknow = Checker::<LemmeKnow>::new();
+            let lemmeknow_result = lemmeknow.check(text);
+            if lemmeknow_result.is_identified {
+                let mut check_res = CheckResult::new(&lemmeknow);
+                check_res.is_identified = human_checker::human_checker(&lemmeknow_result);
+                return check_res;
+            }
 
-        let english = Checker::<EnglishChecker>::new();
-        let english_result = english.check(text);
-        if english_result.is_identified {
-            let mut check_res = CheckResult::new(&english);
-            check_res.is_identified = human_checker::human_checker(&english_result);
-            return check_res;
+            let english = Checker::<EnglishChecker>::new();
+            let english_result = english.check(text);
+            if english_result.is_identified {
+                let mut check_res = CheckResult::new(&english);
+                check_res.is_identified = human_checker::human_checker(&english_result);
+                return check_res;
+            }
         }
 
         CheckResult::new(self)

--- a/src/checkers/athena.rs
+++ b/src/checkers/athena.rs
@@ -1,5 +1,6 @@
 use crate::{checkers::checker_result::CheckResult, config::get_config};
 use lemmeknow::Identifier;
+use log::trace;
 
 use super::{
     checker_type::{Check, Checker},
@@ -30,6 +31,7 @@ impl Check for Checker<Athena> {
         let config = get_config();
         // Only run regex if its in the config
         if config.regex.is_some(){
+            trace!("running regex");
             let regex_checker = Checker::<RegexChecker>::new();
             let regex_result = regex_checker.check(text);
             if regex_result.is_identified {

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -3,7 +3,8 @@ use self::{
     checker_result::CheckResult,
     checker_type::{Check, Checker},
     english::EnglishChecker,
-    lemmeknow_checker::LemmeKnow, regex_checker::RegexChecker,
+    lemmeknow_checker::LemmeKnow,
+    regex_checker::RegexChecker,
 };
 
 /// The default checker we use which simply calls all other checkers in order.

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -3,7 +3,7 @@ use self::{
     checker_result::CheckResult,
     checker_type::{Check, Checker},
     english::EnglishChecker,
-    lemmeknow_checker::LemmeKnow,
+    lemmeknow_checker::LemmeKnow, regex_checker::RegexChecker,
 };
 
 /// The default checker we use which simply calls all other checkers in order.
@@ -31,6 +31,8 @@ pub enum CheckerTypes {
     CheckEnglish(Checker<EnglishChecker>),
     /// Wrapper for Athena Checker
     CheckAthena(Checker<Athena>),
+    /// Wrapper for Regex
+    CheckRegex(Checker<RegexChecker>),
 }
 
 impl CheckerTypes {
@@ -40,6 +42,7 @@ impl CheckerTypes {
             CheckerTypes::CheckLemmeKnow(lemmeknow_checker) => lemmeknow_checker.check(text),
             CheckerTypes::CheckEnglish(english_checker) => english_checker.check(text),
             CheckerTypes::CheckAthena(athena_checker) => athena_checker.check(text),
+            CheckerTypes::CheckRegex(regex_checker) => regex_checker.check(text),
         }
     }
 }

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -20,6 +20,8 @@ pub mod english;
 pub mod human_checker;
 /// The LemmeKnow Checker checks if the text matches a known Regex pattern.
 pub mod lemmeknow_checker;
+/// The Regex checker checks to see if the intended text matches the plaintext
+pub mod regex_checker;
 
 /// CheckerTypes is a wrapper enum for Checker
 pub enum CheckerTypes {

--- a/src/checkers/regex_checker.rs
+++ b/src/checkers/regex_checker.rs
@@ -1,7 +1,7 @@
 use lemmeknow::Identifier;
 
 use super::checker_type::{Check, Checker};
-use crate::{checkers::checker_result::CheckResult, config::{get_config, self}};
+use crate::{checkers::checker_result::CheckResult, config::{get_config}};
 use regex::Regex;
 
 /// The Regex Checker checks if the text matches a known Regex pattern.
@@ -23,17 +23,13 @@ impl Check for Checker<RegexChecker> {
     }
 
     fn check(&self, text: &str) -> CheckResult {
-        lazy_static! {
-            static ref compiled_regex: Regex = {
-                let config = get_config();
-                let regex_to_parse = config.regex.unwrap();
-                Regex::new(regex_to_parse).unwrap()
-            };
-        }
+        // TODO put this into a lazy static so we don't generate it everytime
+        let config = get_config();
+        let regex_to_parse = config.regex.clone();
+        let re = Regex::new(&regex_to_parse.unwrap()).unwrap();
         
-        let regex_check_result = match compiled_regex {
-            _ => {},
-        }
+        let regess_check_result = re.is_match(text);
+        
         
         let mut result = CheckResult { is_identified: false, text: text.to_owned(), description: "".to_string(), checker_name: self.name, checker_description: self.description, link: self.link };
 
@@ -46,19 +42,5 @@ impl Check for Checker<RegexChecker> {
             result.is_identified = true;
         }
         result
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::checkers::{
-        checker_type::{Check, Checker},
-        RegexChecker::regex,
-    };
-
-    #[test]
-    fn test_check_basic() {
-        let checker = Checker::<EnglishChecker>::new();
-        assert!(checker.check("preinterview").is_identified);
     }
 }

--- a/src/checkers/regex_checker.rs
+++ b/src/checkers/regex_checker.rs
@@ -1,0 +1,64 @@
+use lemmeknow::Identifier;
+
+use super::checker_type::{Check, Checker};
+use crate::{checkers::checker_result::CheckResult, config::{get_config, self}};
+use regex::Regex;
+
+/// The Regex Checker checks if the text matches a known Regex pattern.
+/// This is the struct for it.
+pub struct RegexChecker;
+
+impl Check for Checker<RegexChecker> {
+    fn new() -> Self {
+        Checker {
+            name: "Regex Checker",
+            description: "Uses Regex to check for regex matches, useful for finding cribs.",
+            link: "https://github.com/rust-lang/regex",
+            tags: vec!["crib", "regex"],
+            expected_runtime: 0.01,
+            popularity: 1.0,
+            lemmeknow_config: Identifier::default(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    fn check(&self, text: &str) -> CheckResult {
+        lazy_static! {
+            static ref compiled_regex: Regex = {
+                let config = get_config();
+                let regex_to_parse = config.regex.unwrap();
+                Regex::new(regex_to_parse).unwrap()
+            };
+        }
+        
+        let regex_check_result = match compiled_regex {
+            _ => {},
+        }
+        
+        let mut result = CheckResult { is_identified: false, text: text.to_owned(), description: "".to_string(), checker_name: self.name, checker_description: self.description, link: self.link };
+
+        result.checker_name = self.name;
+        result.checker_description = self.description;
+        result.link = self.link;
+        result.text = text.to_owned();
+
+        if regess_check_result {
+            result.is_identified = true;
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::checkers::{
+        checker_type::{Check, Checker},
+        RegexChecker::regex,
+    };
+
+    #[test]
+    fn test_check_basic() {
+        let checker = Checker::<EnglishChecker>::new();
+        assert!(checker.check("preinterview").is_identified);
+    }
+}

--- a/src/checkers/regex_checker.rs
+++ b/src/checkers/regex_checker.rs
@@ -1,7 +1,8 @@
 use lemmeknow::Identifier;
 
 use super::checker_type::{Check, Checker};
-use crate::{checkers::checker_result::CheckResult, config::{get_config}};
+use crate::{checkers::checker_result::CheckResult, config::get_config};
+use log::trace;
 use regex::Regex;
 
 /// The Regex Checker checks if the text matches a known Regex pattern.
@@ -23,24 +24,26 @@ impl Check for Checker<RegexChecker> {
     }
 
     fn check(&self, text: &str) -> CheckResult {
+        trace!("Checking {} with regex", text);
         // TODO put this into a lazy static so we don't generate it everytime
         let config = get_config();
         let regex_to_parse = config.regex.clone();
         let re = Regex::new(&regex_to_parse.unwrap()).unwrap();
-        
-        let regess_check_result = re.is_match(text);
-        
-        
-        let mut result = CheckResult { is_identified: false, text: text.to_owned(), description: "".to_string(), checker_name: self.name, checker_description: self.description, link: self.link };
 
-        result.checker_name = self.name;
-        result.checker_description = self.description;
-        result.link = self.link;
-        result.text = text.to_owned();
-
-        if regess_check_result {
-            result.is_identified = true;
+        let regex_check_result = re.is_match(text);
+        let mut plaintext_found = false;
+        let printed_name = format!("Regex matched: {}", re);
+        if regex_check_result {
+            plaintext_found = true;
         }
-        result
+
+        CheckResult {
+            is_identified: plaintext_found,
+            text: text.to_string(),
+            checker_name: self.name,
+            checker_description: self.description,
+            description: printed_name,
+            link: self.link,
+        }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,6 +37,11 @@ pub struct Opts {
     /// Use instead of `--text`
     #[arg(short, long)]
     file: Option<String>,
+    /// If you have a crib (you know a piece of information in the plaintext)
+    /// Or you want to create a custom regex to check against, you can use the Regex checker below.
+    /// This turns off other checkers (English, LemmeKnow)
+    #[arg(short, long)]
+    regex: Option<String>,
 }
 
 /// Parse CLI Arguments turns a Clap Opts struct, seen above
@@ -117,6 +122,11 @@ fn cli_args_into_config_struct(opts: Opts, text: String) -> (String, Config) {
                 opts.cracking_timeout.unwrap()
             },
             api_mode: opts.api_mode.is_some(),
+            regex: if opts.regex.is_none(){
+                None
+            } else {
+                opts.regex
+            },
         },
     )
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -122,11 +122,7 @@ fn cli_args_into_config_struct(opts: Opts, text: String) -> (String, Config) {
                 opts.cracking_timeout.unwrap()
             },
             api_mode: opts.api_mode.is_some(),
-            regex: if opts.regex.is_none(){
-                None
-            } else {
-                opts.regex
-            },
+            regex: opts.regex,
         },
     )
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,6 +29,8 @@ pub struct Config {
     /// This is used to determine if we should print to stdout
     /// Or return the values
     pub api_mode: bool,
+    /// Regex enables the user to search for a specific regex or crib
+    pub regex: Option<String>,
 }
 
 /// Cell for storing global Config
@@ -63,6 +65,7 @@ impl Default for Config {
             human_checker_on: false,
             timeout: 5,
             api_mode: true,
+            regex: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
     clippy::missing_panics_doc
 )]
 
-
 /// The main crate for the Ares project.
 /// This provides the library API interface for Ares.
 mod api_library_input_struct;
@@ -81,6 +80,7 @@ use self::decoders::crack_results::CrackResult;
 /// assert!(result.is_none());
 /// ```
 pub fn perform_cracking(text: &str, config: Config) -> Option<DecoderResult> {
+    config::set_global_config(config);
     let initial_check_for_plaintext = check_if_input_text_is_plaintext(text);
     if initial_check_for_plaintext.is_identified {
         debug!(
@@ -105,7 +105,6 @@ pub fn perform_cracking(text: &str, config: Config) -> Option<DecoderResult> {
     // let search_tree = searchers::Tree::new(text.to_string());
     // Perform the search algorithm
     // It will either return a failure or success.
-    config::set_global_config(config);
     searchers::search_for_plaintext(text)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@
     clippy::missing_panics_doc
 )]
 
+#[macro_use]
+extern crate lazy_static;
+
 /// The main crate for the Ares project.
 /// This provides the library API interface for Ares.
 mod api_library_input_struct;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@
     clippy::missing_panics_doc
 )]
 
-#[macro_use]
-extern crate lazy_static;
 
 /// The main crate for the Ares project.
 /// This provides the library API interface for Ares.


### PR DESCRIPTION
* Adds custom regex checker, users can supply cribs in the form of regex to Ares to find results.

The new argument is `-r, --regex <REGEX>`