### PR TITLE
Add lowercase to english dict cleaner script

### DIFF
--- a/src/storage/dictionaries/clean.py
+++ b/src/storage/dictionaries/clean.py
@@ -5,15 +5,19 @@
 PUNC = set("!\"#$%&'()*+,-./:;<=>?@[\]^_`{|}~")
 # Anything below length of 2 is rather spammy so we remove it
 MIN_LENGTH = 2
+# Since the English checker normaliser turns words into lowercase, we only want lowercase words in our dict
+LOWERCASE = True
 
 file_name = input("Enter the name of the file you want to modify: ")
 f = open(file_name)
-f2 = open("modfiied_file.txt", "w")
+f2 = open("modified.txt", "w")
 for line in f:
     if len(line) <= MIN_LENGTH:
         continue
     if len(set(line).intersection(PUNC)) != 0:
         continue
+    if LOWERCASE:
+        line = line.lower()
     f2.write(line)
 
 f.close()


### PR DESCRIPTION
Since the English checker normaliser turns words into lowercase, we only want lowercase words in our dict