### PR TITLE
Added a documentation folder

### DIFF
--- a/docs/package-managers.md
+++ b/docs/package-managers.md
@@ -1,0 +1,9 @@
+# Packing Ares
+
+Please call the main Ares program (the CLI) `ares_cli` and enable it to be called via `ares` in the terminal.
+
+This is because `Ares` is a short name and is probably taken in a package manager already.
+
+## Releases
+
+Please base your package on our releases and not our GitHub repo. If you must, please call the package `ares_cli_rolling` to ensure people understand that the package updates on a rolling basis (as our GitHub repo updates).


### PR DESCRIPTION
I am suggesting we write docs in a github folder with markdown because:
* We have version control
* We _could_ put them into a github website or something at some point