### PR TITLE
Cargo.toml: sort dependencies alphabetically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,8 @@ bench = false
 # Please keep this list in alphabetical order
 [dependencies]
 ansi_term = "0.12.1"
-base64 = "0.21.0"
-base65536 = "1.0.1"
-base91 = "0.1.0"
-bs58 = "0.4.0"
 clap = {version = "4.1.8", features = ["derive"]}
 crossbeam = "0.8"
-data-encoding = "2.3.3"
 env_logger = "0.10.0"
 include_dir = "0.7.3"
 lazy-regex = "2.5.0"
@@ -38,6 +33,13 @@ once_cell = "1.17.1"
 rayon = "1.7.0"
 regex = "1.7.1"
 text_io = "0.1.12"
+
+# Dependencies used for decoding
+base64 = "0.21.0"
+base65536 = "1.0.1"
+base91 = "0.1.0"
+bs58 = "0.4.0"
+data-encoding = "2.3.3"
 urlencoding = "2.1.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,26 +17,27 @@ name = "ares"
 path = "src/main.rs"
 bench = false
 
+# Please keep this list in alphabetical order
 [dependencies]
-clap = {version = "4.1.8", features = ["derive"]}
-log = "0.4"
-env_logger = "0.10.0"
-base64 = "0.21.0"
-rayon = "1.7.0"
-lemmeknow = "0.7.0"
-include_dir = "0.7.3"
-once_cell = "1.17.1"
-text_io = "0.1.12"
-data-encoding = "2.3.3"
-bs58 = "0.4.0"
-base91 = "0.1.0"
-num = "0.4"
-crossbeam = "0.8"
-base65536 = "1.0.1"
 ansi_term = "0.12.1"
-lazy_static = "1.4.0"
+base64 = "0.21.0"
+base65536 = "1.0.1"
+base91 = "0.1.0"
+bs58 = "0.4.0"
+clap = {version = "4.1.8", features = ["derive"]}
+crossbeam = "0.8"
+data-encoding = "2.3.3"
+env_logger = "0.10.0"
+include_dir = "0.7.3"
 lazy-regex = "2.5.0"
+lazy_static = "1.4.0"
+lemmeknow = "0.7.0"
+log = "0.4"
+num = "0.4"
+once_cell = "1.17.1"
+rayon = "1.7.0"
 regex = "1.7.1"
+text_io = "0.1.12"
 urlencoding = "2.1.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Since the list is longish, I thought it might be a good idea to keep it sorted in some way.