### PR TITLE
reduce memory usage of bfs

### DIFF
--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -51,46 +51,39 @@ pub fn bfs(input: &str) -> Option<DecoderResult> {
                     None // short-circuits the iterator
                 }
                 MyResults::Continue(results_vec) => {
-                    new_strings.extend(
-                        results_vec
-                            .into_iter()
-                            .map(|r| {
-                                let mut decoders_used = current_string.path.clone();
-                                // text is a vector of strings
-                                let text = r.unencrypted_text.clone().unwrap_or_default();
-                                decoders_used.push(r);
-                                DecoderResult {
-                                    // and this is a vector of strings
-                                    // TODO we should probably loop through all `text` and create Text structs for each one
-                                    // and append those structs
-                                    // I think we should keep text as a single string
-                                    // and just create more of them....
-                                    text,
-                                    path: decoders_used.to_vec(),
-                                }
-                            })
-                            .filter(|s| seen_strings.insert(s.text.clone())),
-                    );
+                    new_strings.extend(results_vec.into_iter().flat_map(|mut r| {
+                        let mut decoders_used = current_string.path.clone();
+                        // text is a vector of strings
+                        let mut text = r.unencrypted_text.take().unwrap_or_default();
+
+                        text.retain(|s| {
+                            !check_if_string_cant_be_decoded(s) && seen_strings.insert(s.clone())
+                        });
+
+                        if text.is_empty() {
+                            return None;
+                        }
+
+                        decoders_used.push(r);
+                        Some(DecoderResult {
+                            // and this is a vector of strings
+                            // TODO we should probably loop through all `text` and create Text structs for each one
+                            // and append those structs
+                            // I think we should keep text as a single string
+                            // and just create more of them....
+                            text,
+                            path: decoders_used.to_vec(),
+                        })
+                    }));
                     Some(()) // indicate we want to continue processing
                 }
             }
         });
-        let mut new_strings_to_be_added = Vec::new();
-        for text_struct in new_strings {
-            for decoded_text in text_struct.text {
-                if check_if_string_cant_be_decoded(&decoded_text) {
-                    continue;
-                }
-                new_strings_to_be_added.push(DecoderResult {
-                    text: vec![decoded_text],
-                    // quick hack
-                    path: text_struct.path.clone(),
-                })
-            }
-        }
-        current_strings = new_strings_to_be_added;
+
+        current_strings = new_strings;
         curr_depth += 1;
 
+        // we don't need select! here, we could use try_recv()
         select! {
             recv(result_recv) -> exit_result => {
                 // if we find an element that matches our exit condition, return it!


### PR DESCRIPTION
we were doing lots of unnecessary allocations, which could be avoided.

- we replace `unencrypted_text` with `None` ( as we don't need it further )
- `seen_strings` should be `HashSet<String>` instead of `HashSet<Vec<String>>`
- check if string is decode-able earlier 