### PR TITLE
DecoderResult for every text in unencrypted_text

### DIFF
--- a/src/searchers/bfs.rs
+++ b/src/searchers/bfs.rs
@@ -54,30 +54,31 @@ pub fn bfs(input: String, result_sender: Sender<Option<DecoderResult>>, stop: Ar
                     None // short-circuits the iterator
                 }
                 MyResults::Continue(results_vec) => {
-                    new_strings.extend(results_vec.into_iter().flat_map(|mut r| {
-                        let mut decoders_used = current_string.path.clone();
-                        // text is a vector of strings
-                        let mut text = r.unencrypted_text.take().unwrap_or_default();
+                    new_strings.extend(
+                        results_vec
+                            .into_iter()
+                            .flat_map(|mut r| {
+                                let mut decoders_used = current_string.path.clone();
+                                // text is a vector of strings
+                                let mut text = r.unencrypted_text.take().unwrap_or_default();
 
-                        text.retain(|s| {
-                            !check_if_string_cant_be_decoded(s) && seen_strings.insert(s.clone())
-                        });
+                                text.retain(|s| {
+                                    !check_if_string_cant_be_decoded(s)
+                                        && seen_strings.insert(s.clone())
+                                });
 
-                        if text.is_empty() {
-                            return None;
-                        }
+                                if text.is_empty() {
+                                    return None;
+                                }
 
-                        decoders_used.push(r);
-                        Some(DecoderResult {
-                            // and this is a vector of strings
-                            // TODO we should probably loop through all `text` and create Text structs for each one
-                            // and append those structs
-                            // I think we should keep text as a single string
-                            // and just create more of them....
-                            text,
-                            path: decoders_used.to_vec(),
-                        })
-                    }));
+                                decoders_used.push(r);
+                                Some(text.into_iter().map(move |t| DecoderResult {
+                                    text: vec![t],
+                                    path: decoders_used.to_vec(),
+                                }))
+                            })
+                            .flatten(),
+                    );
                     Some(()) // indicate we want to continue processing
                 }
             }


### PR DESCRIPTION
In future, we want to refactor:
- DecoderResult to contain `String` instead of `Vec<String>`.
- CrackResult, if we have identified the text successfully, should have only identified text in unencrypted text. i.e. `unencrypted_text.len() == 1`

For doing the later change, we would also need to refactor the decoders.
