### PR TITLE
Changing English checker test to account for Gibberish changes

### DIFF
--- a/src/checkers/english.rs
+++ b/src/checkers/english.rs
@@ -104,7 +104,7 @@ mod tests {
     #[test]
     fn test_check_basic2() {
         let checker = Checker::<EnglishChecker>::new();
-        assert!(checker.check("and").is_identified);
+        assert!(checker.check("exuberant").is_identified);
     }
 
     #[test]

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -140,6 +140,6 @@ mod tests {
     #[test]
     fn test_check_goes_to_dictionary() {
         let athena = CheckerTypes::CheckAthena(Checker::<Athena>::new());
-        assert!(athena.check("and").is_identified);
+        assert!(athena.check("exuberant").is_identified);
     }
 }

--- a/src/checkers/wait_athena.rs
+++ b/src/checkers/wait_athena.rs
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn test_check_dictionary_word() {
         let checker = Checker::<WaitAthena>::new();
-        assert!(checker.check("and").is_identified);
+        assert!(checker.check("exuberant").is_identified);
     }
 
     #[test]


### PR DESCRIPTION
With the new update of ``gibberish_or_not``, "and" is now classified as gibberish so one of the two basic English checker tests fails. Since two of the Athena-related checkers also call the English checker at some point, their relevant tests also fail. This PR updates the test to use a different word that's not classified as gibberish.